### PR TITLE
enable package inside module

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ class ServerlessWSGI {
   validate() {
     if (this.serverless.service.custom && this.serverless.service.custom.wsgi && this.serverless.service.custom.wsgi.app) {
       this.wsgiApp = this.serverless.service.custom.wsgi.app;
+      this.appPath = path.dirname(path.join(this.serverless.config.servicePath, this.wsgiApp))
     }
   };
 
@@ -34,7 +35,8 @@ class ServerlessWSGI {
   };
 
   packRequirements() {
-    const requirementsFile = path.join(this.serverless.config.servicePath, 'requirements.txt');
+    const requirementsPath = this.appPath || this.serverless.config.servicePath
+    const requirementsFile = path.join(requirementsPath, 'requirements.txt');
     let args = [path.resolve(__dirname, 'requirements.py')];
 
     if (this.wsgiApp) {

--- a/serve.py
+++ b/serve.py
@@ -25,7 +25,7 @@ PORT = int(sys.argv[3])
 sys.path.insert(0, CWD)
 
 wsgi_fqn = APP.rsplit('.', 1)
-wsgi_module = importlib.import_module(wsgi_fqn[0])
+wsgi_module = importlib.import_module(wsgi_fqn[0].replace('/', '.'))
 wsgi_app = getattr(wsgi_module, wsgi_fqn[1])
 
 # Attempt to force Flask into debug mode

--- a/wsgi.py
+++ b/wsgi.py
@@ -23,7 +23,7 @@ from werkzeug._compat import wsgi_encoding_dance  # noqa: E402
 
 with open(os.path.join(root, '.wsgi_app'), 'r') as f:
     wsgi_fqn = f.read().rsplit('.', 1)
-    wsgi_module = importlib.import_module(wsgi_fqn[0])
+    wsgi_module = importlib.import_module(wsgi_fqn[0].replace('/', '.'))
     wsgi_app = getattr(wsgi_module, wsgi_fqn[1])
 
 


### PR DESCRIPTION
This PR enables having a an WSGI app in a module below the root where the `serverless.yml` is (e.g. `app/api.py`), in order to allow a more flexible structure, specially when having multiple functions in the same service.

