### PR TITLE
Packages requirements inside function directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ class ServerlessWSGI {
   packRequirements() {
     const requirementsPath = this.appPath || this.serverless.config.servicePath;
     const requirementsFile = path.join(requirementsPath, 'requirements.txt');
+    const requirementsInstallPath = this.appPath ? this.appPath : this.serverless.config.servicePath;
     let args = [path.resolve(__dirname, 'requirements.py')];
 
     if (this.serverless.service.custom && this.serverless.service.custom.wsgi && this.serverless.service.custom.wsgi.packRequirements == false) {
@@ -55,7 +56,7 @@ class ServerlessWSGI {
       }
     }
 
-    args.push(path.join(this.serverless.config.servicePath, '.requirements'));
+    args.push(path.join(requirementsInstallPath, '.requirements'));
 
     this.serverless.cli.log('Packaging required Python packages...');
 

--- a/index.test.js
+++ b/index.test.js
@@ -166,7 +166,7 @@ describe('serverless-wsgi', function() {
             path.resolve(__dirname, 'requirements.py'),
             path.resolve(__dirname, 'requirements.txt'),
             '/tmp/api/requirements.txt',
-            '/tmp/.requirements'
+            '/tmp/api/.requirements'
           ]
         )).to.be.ok;
         sandbox.restore();

--- a/wsgi.py
+++ b/wsgi.py
@@ -11,8 +11,14 @@ Author: Logan Raarup <logan@logan.dk>
 """
 import os
 import sys
+
 root = os.path.abspath(os.path.join(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(root, '.requirements'))
+with open(os.path.join(root, '.wsgi_app'), 'r') as f:
+    app_path = f.read()
+    wsgi_fqn = app_path.rsplit('.', 1)
+app_dir = os.path.dirname(os.path.abspath(app_path))
+requirements_path = os.path.join(root, app_dir, '.requirements')
+sys.path.insert(0, requirements_path)
 
 import importlib  # noqa: E402
 from StringIO import StringIO  # noqa: E402
@@ -21,10 +27,8 @@ from werkzeug.wrappers import Response  # noqa: E402
 from werkzeug.urls import url_encode  # noqa: E402
 from werkzeug._compat import wsgi_encoding_dance  # noqa: E402
 
-with open(os.path.join(root, '.wsgi_app'), 'r') as f:
-    wsgi_fqn = f.read().rsplit('.', 1)
-    wsgi_module = importlib.import_module(wsgi_fqn[0].replace('/', '.'))
-    wsgi_app = getattr(wsgi_module, wsgi_fqn[1])
+wsgi_module = importlib.import_module(wsgi_fqn[0].replace('/', '.'))
+wsgi_app = getattr(wsgi_module, wsgi_fqn[1])
 
 
 def handler(event, context):


### PR DESCRIPTION
This PR packages the `.requirements` directory inside the `appPath`. This approach allows better dependency encapsulation when using multiple functions in the same service.