### PR TITLE
Adds context to request environ

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -84,6 +84,8 @@ def handler(event, context):
             headers.get(u'X-Forwarded-Port', '80'),
         'SERVER_PROTOCOL':
             'HTTP/1.1',
+        'context':
+            context,
         'wsgi.errors':
             StringIO(),
         'wsgi.input':


### PR DESCRIPTION
So we can use lambda info such as  `context.log_group_name` and `context.log_stream_name`.