### PR TITLE
Support for 'bytes' response.data

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -9,6 +9,7 @@ Inspired by: https://github.com/miserlou/zappa
 
 Author: Logan Raarup <logan@logan.dk>
 """
+import base64
 import os
 import sys
 
@@ -138,8 +139,16 @@ def handler(event, context):
     elif len(cookie_headers) == 1:
         new_headers.extend(cookie_headers)
 
-    return {
+    returndict = {
         u'statusCode': response.status_code,
-        u'headers': dict(new_headers),
-        u'body': response.data
+        u'headers': dict(new_headers)
     }
+
+    if response.data:
+        if isinstance(response.data, bytes):
+            returndict['body'] = base64.b64encode(response.data).decode('utf-8')
+            returndict["isBase64Encoded"] = "true"
+        else:
+            returndict['body'] = response.data
+
+    return returndict

--- a/wsgi.py
+++ b/wsgi.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 PY2 = sys.version_info[0] == 2
+TEXT_MIME_TYPES = ['application/json', 'application/xml']
 
 root = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(root, '.wsgi_app'), 'r') as f:
@@ -144,11 +145,16 @@ def handler(event, context):
         u'headers': dict(new_headers)
     }
 
-    if response.data:
-        if isinstance(response.data, bytes):
-            returndict['body'] = base64.b64encode(response.data).decode('utf-8')
-            returndict["isBase64Encoded"] = "true"
+    data = response.data
+    if data:
+        if isinstance(data, bytes):
+            mimetype = response.mimetype or 'text/plain'
+            if mimetype.startswith('text/') or mimetype in TEXT_MIME_TYPES:
+                returndict['body'] = data.decode('utf-8')
+            else:
+                returndict['body'] = base64.b64encode(data).decode('utf-8')
+                returndict["isBase64Encoded"] = "true"
         else:
-            returndict['body'] = response.data
+            returndict['body'] = data
 
     return returndict


### PR DESCRIPTION
Anything returned from Flask in Python v3.6.1 (now supported by Lambda) seems to return a byte string ('bytes') rather than a string.

This causes the serialization of the return dictionary to fail in awslambda/bootstrap.py.

This patch checks for a byte string, and if it exists, serializes it to be safely passed back to API gateway.

Note that Zappa has a similar implementation that seems to always serialize bytes due to a fault in their logic that always returns true:
See: https://github.com/Miserlou/Zappa/blob/master/zappa/handler.py#L433-L442
 