### PR TITLE
Fix python directory for python3.6 on mac os

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -52,7 +52,15 @@ def package(req_files, target_dir):
         deps_dir = os.path.join(venv_dir, 'Lib', 'site-packages')
     else:
         pip_exe = os.path.join(venv_dir, 'bin', 'pip')
-        python_dir = os.listdir(os.path.join(venv_dir, 'lib'))[0]
+        lib_path = os.path.join(venv_dir, 'lib')
+        libs_dir_path_items = os.listdir(lib_path)
+        directories = [d for d in libs_dir_path_items
+                         if os.path.isdir(os.path.join(lib_path, d)) and
+                         'python' in d.lower()]
+        if len(directories) > 0:
+            python_dir = directories[0]
+        else:
+            sys.exit('No python directory')
         deps_dir = os.path.join(venv_dir, 'lib', python_dir, 'site-packages')
 
     if not os.path.isfile(pip_exe):

--- a/requirements.py
+++ b/requirements.py
@@ -55,7 +55,7 @@ def package(req_files, target_dir):
         lib_path = os.path.join(venv_dir, 'lib')
         libs_dir_path_items = os.listdir(lib_path)
         directories = [d for d in libs_dir_path_items
-                         if os.path.isdir(os.path.join(lib_path, d))]
+                       if os.path.isdir(os.path.join(lib_path, d))]
         if len(directories) > 0:
             python_dir = directories[0]
         else:

--- a/requirements.py
+++ b/requirements.py
@@ -55,8 +55,7 @@ def package(req_files, target_dir):
         lib_path = os.path.join(venv_dir, 'lib')
         libs_dir_path_items = os.listdir(lib_path)
         directories = [d for d in libs_dir_path_items
-                         if os.path.isdir(os.path.join(lib_path, d)) and
-                         'python' in d.lower()]
+                         if os.path.isdir(os.path.join(lib_path, d))]
         if len(directories) > 0:
             python_dir = directories[0]
         else:

--- a/requirements_test.py
+++ b/requirements_test.py
@@ -95,6 +95,10 @@ def test_package(mock_system, mock_virtualenv):
 
     # Looks for pip installation
     assert mock_system.pop(0) == ('os.listdir', ('/tmp/.venv/lib',))
+
+    assert mock_system.pop(0) == ('os.path.isdir', ('/tmp/.venv/lib/dir1',))
+    assert mock_system.pop(0) == ('os.path.isdir', ('/tmp/.venv/lib/dir2',))
+
     assert mock_system.pop(0) == ('os.path.isfile', ('/tmp/.venv/bin/pip',))
 
     # Invokes pip for package installation


### PR DESCRIPTION
Hi!

Some thing strange with working on Mac OS and Python3.6 (Anaconda). When deploy it fails with a bad python_dir path.
I am interested in continuing developing this plugin, please contact me if you need any help.