### PR TITLE
Don't cleanup .requirements/ if packRequirements: false

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,10 @@ class ServerlessWSGI {
   }
 
   cleanup() {
-    const artifacts = ['wsgi.py', '.wsgi_app', '.requirements'];
+    const artifacts = ['wsgi.py', '.wsgi_app'];
+    if (this.serverless.service.custom && this.serverless.service.custom.wsgi && (this.serverless.service.custom.wsgi.packRequirements !== false)) {
+      artifacts.push('.requirements');
+    }
 
     return BbPromise.all(_.map(artifacts, (artifact) =>
       fse.removeAsync(path.join(this.serverless.config.servicePath, artifact))));

--- a/index.test.js
+++ b/index.test.js
@@ -293,6 +293,27 @@ describe('serverless-wsgi', function() {
         sandbox.restore();
       });
     });
+
+    it('skips requirements cleanup if chosen', function() {
+      var plugin = new Plugin({
+        config: { servicePath: '/tmp' },
+        service: {
+          custom: { wsgi: { app: 'api.app', packRequirements: false } }
+        },
+        classes: { Error: Error },
+        cli: { log: function () {} }
+      }, {});
+
+      var sandbox = sinon.sandbox.create();
+      var remove_stub = sandbox.stub(fse, 'removeAsync');
+      plugin.hooks['after:deploy:createDeploymentArtifacts']().then(function () {
+        expect(remove_stub.calledWith('/tmp/wsgi.py')).to.be.ok;
+        expect(remove_stub.calledWith('/tmp/.wsgi_app')).to.be.ok;
+        expect(remove_stub.calledWith('/tmp/.requirements')).to.be.false;
+        sandbox.restore();
+      });
+
+    });
   });
 
   describe('function deployment', function() {


### PR DESCRIPTION
## What this does:

Upon cleanup, don't remove the `.requirements/` directory if the user has set `packRequirements: true`.

## Why

I like to use the [serverless-python-requirements](https://github.com/UnitedIncome/serverless-python-requirements) plugin to manage Python dependencies in my Serverless services. The cross-compiling feature is really helpful, plus it's nice to use the same requirements tool for all my Serverless services, even non-Flask ones.

Because of this, I set `packRequirements: false` in my `serverless.yml` file. This causes serverless-wsgi to avoid installing the requirements, but it still tries to clean up the `.requirements/` directory [here](https://github.com/logandk/serverless-wsgi/blob/9dc67c74b06f117259a6b18999852dc3ff7a45e1/index.js#L83-L88).

I found [this issue](https://github.com/UnitedIncome/serverless-python-requirements/issues/22#issuecomment-295672879) with a workaround of naming the serverless-python-requirements plugin before the serverless-wsgi file. However, this is likely to trip up other users. Further, I was still getting subtle bugs even with that workaround.

Love the plugin and appreciate your work on it. Happy to make any changes if you prefer a different way!