### PR TITLE
Only add .requirements folder to includes when packing enabled.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,14 @@ class ServerlessWSGI {
     this.serverless.service.package = this.serverless.service.package || {};
     this.serverless.service.package.include = this.serverless.service.package.include || [];
 
+    var includes = ['wsgi.py', '.wsgi_app'];
+    if (this.serverless.service.custom.wsgi.packRequirements) {
+      includes.push('.requirements/**');
+    }
+
     this.serverless.service.package.include = _.union(
       this.serverless.service.package.include,
-      ['wsgi.py', '.wsgi_app', '.requirements/**']
+      includes
     );
   }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ class ServerlessWSGI {
     this.serverless.service.package.include = this.serverless.service.package.include || [];
 
     var includes = ['wsgi.py', '.wsgi_app'];
-    if (this.serverless.service.custom.wsgi.packRequirements) {
+    if (this.serverless.service.custom === undefined || this.serverless.service.custom.wsgi === undefined ||
+          (this.serverless.service.custom.wsgi.packRequirements !== false)) {
       includes.push('.requirements/**');
     }
 


### PR DESCRIPTION
Hi, just wanted to say I'm a big fan of serverless-wsgi, it's super useful.
Anyway, I was running into an edge case when using this library in conjunction with the serverless-python-requirements . That library also uses a .requirements folder, but expects it to be excluded, whereas this library forces it to be included. This means when I deploy, all the python libs are included twice in my package, doubling the deploy size. It seems to make sense to me that serverless-wsgi shouldn't try to include the .requirements folder if it isn't doing any packaging. 

Let me know what you think.