### PR TITLE
Fix handling of binary request payloads and compressed responses.

### DIFF
--- a/wsgi_test.py
+++ b/wsgi_test.py
@@ -394,6 +394,25 @@ def test_handler_base64(mock_wsgi_app_file, mock_app, event):
     }
 
 
+def text_handler_base64_request(mock_wsgi_app_file, mock_app, event):
+    import wsgi  # noqa: F811
+    event['body'] = 'SGVsbG8gd29ybGQ='
+    event['headers']['Content-Type'] = 'text/plain'
+    event['isBase64Encoded'] = True
+    event['httpMethod'] = 'PUT'
+
+    wsgi.handler(event, {'memory_limit_in_mb': '128'})
+
+    assert wsgi.wsgi_app.last_environ['CONTENT_TYPE'] == 'text/plain', \
+        'Content type set incorrectly'
+    assert wsgi.wsgi_app.last_environ['CONTENT_LENGTH'] == 11, \
+        'Content length calculated incorrectly'
+    assert wsgi.wsgi_app.last_environ['REQUEST_METHOD'] == 'PUT', \
+        'Request-Method set incorrectly'
+    assert wsgi.wsgi_app.last_environ['wsgi.input'].getvalue() == 'Hello world', \
+        'Request body decoded incorrectly'
+
+
 def test_non_package_subdir_app(mock_subdir_wsgi_app_file, mock_app):
     del sys.modules['wsgi']
     import wsgi  # noqa: F811

--- a/wsgi_test.py
+++ b/wsgi_test.py
@@ -394,7 +394,7 @@ def test_handler_base64(mock_wsgi_app_file, mock_app, event):
     }
 
 
-def text_handler_base64_request(mock_wsgi_app_file, mock_app, event):
+def test_handler_base64_request(mock_wsgi_app_file, mock_app, event):
     import wsgi  # noqa: F811
     event['body'] = 'SGVsbG8gd29ybGQ='
     event['headers']['Content-Type'] = 'text/plain'
@@ -405,7 +405,7 @@ def text_handler_base64_request(mock_wsgi_app_file, mock_app, event):
 
     assert wsgi.wsgi_app.last_environ['CONTENT_TYPE'] == 'text/plain', \
         'Content type set incorrectly'
-    assert wsgi.wsgi_app.last_environ['CONTENT_LENGTH'] == 11, \
+    assert wsgi.wsgi_app.last_environ['CONTENT_LENGTH'] == '11', \
         'Content length calculated incorrectly'
     assert wsgi.wsgi_app.last_environ['REQUEST_METHOD'] == 'PUT', \
         'Request-Method set incorrectly'

--- a/wsgi_test.py
+++ b/wsgi_test.py
@@ -409,7 +409,7 @@ def test_handler_base64_request(mock_wsgi_app_file, mock_app, event):
         'Content length calculated incorrectly'
     assert wsgi.wsgi_app.last_environ['REQUEST_METHOD'] == 'PUT', \
         'Request-Method set incorrectly'
-    assert wsgi.wsgi_app.last_environ['wsgi.input'].getvalue() == \
+    assert wsgi.wsgi_app.last_environ['wsgi.input'].getvalue().decode() == \
         'Hello world', 'Request body decoded incorrectly'
 
 

--- a/wsgi_test.py
+++ b/wsgi_test.py
@@ -409,8 +409,8 @@ def text_handler_base64_request(mock_wsgi_app_file, mock_app, event):
         'Content length calculated incorrectly'
     assert wsgi.wsgi_app.last_environ['REQUEST_METHOD'] == 'PUT', \
         'Request-Method set incorrectly'
-    assert wsgi.wsgi_app.last_environ['wsgi.input'].getvalue() == 'Hello world', \
-        'Request body decoded incorrectly'
+    assert wsgi.wsgi_app.last_environ['wsgi.input'].getvalue() == \
+        'Hello world', 'Request body decoded incorrectly'
 
 
 def test_non_package_subdir_app(mock_subdir_wsgi_app_file, mock_app):


### PR DESCRIPTION
Hi there! Thanks so much for developing and maintaining this amazing plugin!
I ran into an issue lately when handling binary data in Lambda with serverless-wsgi and thought I'd submit a PR to fix it:

Issue
- When working with binary request payloads, API Gateway passes the request body into the lambda as base64-encoded data, and serverless-wsgi didn't have any checking for decoding it.
- When using compressed responses such as gzip-encoded JSON, serverless-wsgi treated it as a "text MIME type", passing it along to API gateway without properly base64-encoding it.

Solution
- Check the `event` for API Gateway's `isBase64Encoded` attribute, and decode the body if needed.
- Make sure any encoding is done before the new content-length is calculated.
- Check for a `Content-Encoding` in the header of the response, if there is a content encoding specified, even for text MIME types, it should be returned as base64-encoded binary for API Gateway to decode