### PR TITLE
Add IS_OFFLINE environment variable to serve

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -31,6 +31,8 @@ def serve(cwd, app, port):
     except:
         pass
 
+    os.environ['IS_OFFLINE'] = 'True'
+
     serving.run_simple(
         'localhost', int(port), wsgi_app,
         use_debugger=True, use_reloader=True, use_evalex=True)


### PR DESCRIPTION
Adds an `IS_OFFLINE` environment variable when running locally with `sls wsgi serve`.

It's often useful to know when you're developing locally, such as when configuring the boto3 client to work with a local DynamoDB emulator using [serverless-dynamodb-local](https://github.com/99xt/serverless-dynamodb-local). I chose to use `IS_OFFLINE` as it mirrors the same env variable used in [serverless-offline](https://github.com/dherault/serverless-offline), which is a popular local emulator for NodeJS apps.