### PR TITLE
Fix body encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-wsgi",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/wsgi.py
+++ b/wsgi.py
@@ -11,6 +11,7 @@ Author: Logan Raarup <logan@logan.dk>
 """
 import base64
 import os
+import six
 import sys
 
 TEXT_MIME_TYPES = ['application/json', 'application/xml']
@@ -75,7 +76,8 @@ def handler(event, context):
     body = event[u'body'] or ''
     if event.get('isBase64Encoded', False):
         body = base64.b64decode(body)
-    body = to_bytes(wsgi_encoding_dance(body))
+    if isinstance(body, six.string_types):
+        body = to_bytes(wsgi_encoding_dance(body))
 
     environ = {
         'API_GATEWAY_AUTHORIZER':

--- a/wsgi_test.py
+++ b/wsgi_test.py
@@ -445,7 +445,4 @@ def test_handler_binary_request_body(mock_wsgi_app_file, mock_app, event):
 
     environ = wsgi.wsgi_app.last_environ
 
-    if PY2:
-        assert environ['CONTENT_LENGTH'] == '496'
-    else:
-        assert environ['CONTENT_LENGTH'] == '507'
+    assert environ['CONTENT_LENGTH'] == '496'


### PR DESCRIPTION
Fixes #45.

I looked at [how Zappa handles binary content](https://github.com/Miserlou/Zappa/blob/master/zappa/wsgi.py#L69-L81), and I think this fix will work. Previously, we would do the `wsgi_encoding_dance()` and conversion `to_bytes()` on _all_ bodies, regardless of their content. Now, we only do that dance + conversion if the body is a string type. If the body is a bytes object, it will remain as is.

I had to change a test since the `Content-Length` is now different. It now is the same on Python 2 & 3 🎉. However, I don't know enough about encodings to know for sure that this won't break other things.

In addition to running the unit tests, I also confirmed this worked with my app where I was experiencing this problem.