### PR TITLE
Enables different host for the Werkzeug server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ admin.env
 *.pyc
 __pycache__
 .cache
+
+env/

--- a/index.js
+++ b/index.js
@@ -187,7 +187,8 @@ class ServerlessWSGI {
         path.resolve(__dirname, 'serve.py'),
         this.serverless.config.servicePath,
         this.wsgiApp,
-        port
+        port,
+        host
       ], { stdio: 'inherit' });
       if (status.error) {
         reject(status.error);

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ class ServerlessWSGI {
                 shortcut: 'p',
               },
               host: {
-                usage: 'The server host, defaults to \'localhost\'.'
+                usage: 'The server host, defaults to \'localhost\'.',
               },
             },
           },

--- a/index.js
+++ b/index.js
@@ -213,6 +213,10 @@ class ServerlessWSGI {
                 usage: 'The local server port, defaults to 5000.',
                 shortcut: 'p',
               },
+              host: {
+                usage: 'The server host, defaults to localhost.',
+                shortcut: 'h',
+              },
             },
           },
           clean: {

--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ class ServerlessWSGI {
     }
 
     const port = this.options.port || 5000;
-    const hostname = this.options.hostname || 'localhost';
+    const host = this.options.host || 'localhost';
 
     return new BbPromise((resolve, reject) => {
       var status = child_process.spawnSync(this.pythonBin, [
@@ -188,7 +188,7 @@ class ServerlessWSGI {
         this.serverless.config.servicePath,
         this.wsgiApp,
         port,
-        hostname
+        host
       ], { stdio: 'inherit' });
       if (status.error) {
         reject(status.stdout.toString());
@@ -215,9 +215,8 @@ class ServerlessWSGI {
                 usage: 'The local server port, defaults to 5000.',
                 shortcut: 'p',
               },
-              hostname: {
-                usage: 'The server hostname, defaults to \'localhost\'.',
-                shortcut: 'host',
+              host: {
+                usage: 'The server host, defaults to \'localhost\'.'
               },
             },
           },

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ class ServerlessWSGI {
                 shortcut: 'p',
               },
               host: {
-                usage: 'The server host, defaults to localhost.',
+                usage: 'The server host, defaults to \'localhost\'.',
                 shortcut: 'h',
               },
             },

--- a/index.js
+++ b/index.js
@@ -191,8 +191,7 @@ class ServerlessWSGI {
         hostname
       ], { stdio: 'inherit' });
       if (status.error) {
-        console.output(status.error);
-        reject(status.error);
+        reject(status.stdout.toString());
       } else {
         resolve();
       }

--- a/index.js
+++ b/index.js
@@ -191,6 +191,7 @@ class ServerlessWSGI {
         hostname
       ], { stdio: 'inherit' });
       if (status.error) {
+        console.output(status.error);
         reject(status.error);
       } else {
         resolve();

--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ class ServerlessWSGI {
     }
 
     const port = this.options.port || 5000;
-    const host = this.options.host || 'localhost';
+    const hostname = this.options.hostname || 'localhost';
 
     return new BbPromise((resolve, reject) => {
       var status = child_process.spawnSync(this.pythonBin, [
@@ -188,7 +188,7 @@ class ServerlessWSGI {
         this.serverless.config.servicePath,
         this.wsgiApp,
         port,
-        host
+        hostname
       ], { stdio: 'inherit' });
       if (status.error) {
         reject(status.error);
@@ -215,8 +215,8 @@ class ServerlessWSGI {
                 usage: 'The local server port, defaults to 5000.',
                 shortcut: 'p',
               },
-              host: {
-                usage: 'The server host, defaults to \'localhost\'.',
+              hostname: {
+                usage: 'The server hostname, defaults to \'localhost\'.',
                 shortcut: 'h',
               },
             },

--- a/index.js
+++ b/index.js
@@ -180,6 +180,7 @@ class ServerlessWSGI {
     }
 
     const port = this.options.port || 5000;
+    const host = this.options.host || 'localhost';
 
     return new BbPromise((resolve, reject) => {
       var status = child_process.spawnSync(this.pythonBin, [

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ class ServerlessWSGI {
               },
               hostname: {
                 usage: 'The server hostname, defaults to \'localhost\'.',
-                shortcut: 'h',
+                shortcut: 'host',
               },
             },
           },

--- a/index.test.js
+++ b/index.test.js
@@ -553,7 +553,8 @@ describe('serverless-wsgi', () => {
             path.resolve(__dirname, 'serve.py'),
             '/tmp',
             'api.app',
-            5000
+            5000,
+            'localhost'
           ],
           { stdio: 'inherit' }
         )).to.be.true;
@@ -579,7 +580,8 @@ describe('serverless-wsgi', () => {
             path.resolve(__dirname, 'serve.py'),
             '/tmp',
             'api.app',
-            8000
+            8000,
+            'localhost'
           ],
           { stdio: 'inherit' }
         )).to.be.true;

--- a/index.test.js
+++ b/index.test.js
@@ -527,7 +527,8 @@ describe('serverless-wsgi', () => {
             path.resolve(__dirname, 'serve.py'),
             '/tmp',
             'api.app',
-            5000
+            5000,
+            'localhost'
           ],
           { stdio: 'inherit' }
         )).to.be.true;

--- a/serve.py
+++ b/serve.py
@@ -39,7 +39,7 @@ def serve(cwd, app, port, host='localhost'):
 
 
 if __name__ == '__main__':  # pragma: no cover
-    if len(sys.argv) != 4:
+    if len(sys.argv) != 5:
         sys.exit('Usage: {} CWD APP PORT'.format(
             os.path.basename(sys.argv[0])))
 

--- a/serve.py
+++ b/serve.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover
     sys.exit('Unable to import werkzeug (run: pip install werkzeug)')
 
 
-def serve(cwd, app, port, host='localhost'):
+def serve(cwd, app, port, host):
     sys.path.insert(0, cwd)
 
     wsgi_fqn = app.rsplit('.', 1)

--- a/serve.py
+++ b/serve.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover
     sys.exit('Unable to import werkzeug (run: pip install werkzeug)')
 
 
-def serve(cwd, app, port):
+def serve(cwd, app, port, host='localhost'):
     sys.path.insert(0, cwd)
 
     wsgi_fqn = app.rsplit('.', 1)
@@ -34,7 +34,7 @@ def serve(cwd, app, port):
     os.environ['IS_OFFLINE'] = 'True'
 
     serving.run_simple(
-        'localhost', int(port), wsgi_app,
+        str(host), int(port), wsgi_app,
         use_debugger=True, use_reloader=True, use_evalex=True)
 
 

--- a/serve.py
+++ b/serve.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover
     sys.exit('Unable to import werkzeug (run: pip install werkzeug)')
 
 
-def serve(cwd, app, port, host):
+def serve(cwd, app, port, host='localhost'):
     sys.path.insert(0, cwd)
 
     wsgi_fqn = app.rsplit('.', 1)

--- a/serve.py
+++ b/serve.py
@@ -34,13 +34,18 @@ def serve(cwd, app, port, host):
     os.environ['IS_OFFLINE'] = 'True'
 
     serving.run_simple(
-        str(host), int(port), wsgi_app,
-        use_debugger=True, use_reloader=True, use_evalex=True)
+                       str(host),
+                       int(port),
+                       wsgi_app,
+                       use_debugger=True,
+                       use_reloader=True,
+                       use_evalex=True
+                      )
 
 
 if __name__ == '__main__':  # pragma: no cover
     if len(sys.argv) != 5:
-        sys.exit('Usage: {} CWD APP PORT'.format(
+        sys.exit('Usage: {} CWD APP PORT HOST'.format(
             os.path.basename(sys.argv[0])))
 
     serve(*sys.argv[1:])

--- a/serve_test.py
+++ b/serve_test.py
@@ -65,6 +65,21 @@ def test_serve(mock_path, mock_importlib, mock_werkzeug):
     }
 
 
+def test_serve_alternative_hostname(mock_path, mock_importlib, mock_werkzeug):
+    serve.serve('/tmp1', 'app.app', '5000', '0.0.0.0')
+    assert len(mock_path) == 1
+    assert mock_path[0] == '/tmp1'
+    assert mock_werkzeug.lastcall.host == '0.0.0.0'
+    assert mock_werkzeug.lastcall.port == 5000
+    assert mock_werkzeug.lastcall.app.module == 'app'
+    assert mock_werkzeug.lastcall.app.debug
+    assert mock_werkzeug.lastcall.kwargs == {
+        'use_reloader': True,
+        'use_debugger': True,
+        'use_evalex': True
+    }
+
+
 def test_serve_from_subdir(mock_path, mock_importlib, mock_werkzeug):
     serve.serve('/tmp2', 'subdir/app.app', '5000')
     assert len(mock_path) == 2


### PR DESCRIPTION
I like to configure my projects to run on Docker so I can easily test things locally by adding the missing pieces (database, cache, etc) to my docker-compose.yml file. In short, I needed to make some changes to make your package work inside of a container.

I LOVED your project because it is simple and effective, plus you already have a feature to load ENV vars described in the serverless.yml file inside the dev environment and it saves me some copy and paste. 

I wanted to take advantage of that and also continue to use Docker for my dev environment, however, when I was setting my Docker environment I realized that I couldn't span up a server to run inside a container because your Werkzeug runs the server by default on localhost and there isn't an option to change that. I needed to run the server on '0.0.0.0' in order to make it work and this PR enables this feature.

I hope you can use my work to update yours and thanks for the awesome project 👏 👏 👏 

