### PR TITLE
Add 'application/vnd.api+json' to MIME_TYPES

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -13,7 +13,7 @@ import base64
 import os
 import sys
 
-TEXT_MIME_TYPES = ['application/json', 'application/xml']
+TEXT_MIME_TYPES = ['application/json', 'application/xml', 'application/vnd.api+json']
 
 import importlib  # noqa: E402
 from werkzeug.datastructures import Headers  # noqa: E402


### PR DESCRIPTION
This allows proper output (not base64-encoded) when using
django-rest-framework-json-api.