### PR TITLE
Fix to support body's character code other than latin1

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -80,7 +80,7 @@ def handler(event, context):
     if event.get('isBase64Encoded', False):
         body = base64.b64decode(body)
     if isinstance(body, string_types):
-        body = to_bytes(wsgi_encoding_dance(body))
+        body = to_bytes(body)
 
     environ = {
         'API_GATEWAY_AUTHORIZER':


### PR DESCRIPTION
When `wsgi_encoding_dance ()`  is used, body character code is limited to decodeable character string with latin1.

e.g. 

```python
body = 'latin1_char'  # decodable
decoded = wsgi_encoding_dance(body)
# decoded: 'latin1_char'

body = 'テスト_char'  # unable to decode
decoded = wsgi_encoding_dance(body)
# decoded: 'ã\x83\x86ã\x82¹ã\x83\x88_char'
```

I confirmed this, worked with my app where I was experiencing this problem.

Sorry for my troublesome mother tongue in programming :'( 