### PR TITLE
handle request from serverless-plugin-warmup

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -58,7 +58,7 @@ def all_casings(input_string):
 
 
 def handler(event, context):
-    if event['source'] == 'serverless-plugin-warmup':
+    if event.get('source') == 'serverless-plugin-warmup':
         return {}
 
     headers = Headers(event[u'headers'])

--- a/wsgi.py
+++ b/wsgi.py
@@ -58,6 +58,9 @@ def all_casings(input_string):
 
 
 def handler(event, context):
+    if event['source'] == 'serverless-plugin-warmup':
+        return {}
+
     headers = Headers(event[u'headers'])
 
     if headers.get(u'Host', u'').endswith(u'.amazonaws.com'):

--- a/wsgi_test.py
+++ b/wsgi_test.py
@@ -275,6 +275,13 @@ def test_handler_no_cookie(mock_wsgi_app_file, mock_app, event):
     }
 
 
+def test_handler_warmup_plugin(mock_wsgi_app_file, mock_app, event):
+    import wsgi  # noqa: F811
+    event = {'source': 'serverless-plugin-warmup'}
+    response = wsgi.handler(event, {})
+    assert response == {}
+
+
 def test_handler_custom_domain(mock_wsgi_app_file, mock_app, event):
     import wsgi  # noqa: F811
     event['headers']['Host'] = 'custom.domain.com'


### PR DESCRIPTION
Not sure if this is the best way but i am using `serverless-wsgi` with `serverless-plugin-warmup` and `serverless-plugin-aws-alerts`

By default, the `serverless-plugin-warmup` triggers the handler without `headers` or `path` in the `event` variable so the lambda function always crash with key error thus triggering alert set by the `serverless-plugin-aws-alerts`. let me know if there is a better way to handle this.


Reference
https://www.npmjs.com/package/serverless-plugin-warmup
https://www.npmjs.com/package/serverless-plugin-aws-alerts

