### PR TITLE
Enable zip dependencies when using the Python requirements plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ class ServerlessWSGI {
                 shortcut: 'p',
               },
               host: {
-                usage: 'The server host, defaults to \'localhost\'.'
+                usage: 'The server host, defaults to \'localhost\'.',
               },
             },
           },

--- a/wsgi.py
+++ b/wsgi.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 try:
-    import unzip_requirements
+    import unzip_requirements  # pylint: disable=unused-import
 except ImportError:
     pass
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 try:
-    import unzip_requirements  # pylint: disable=unused-import
+    import unzip_requirements  # noqa # pylint: disable=unused-import
 except ImportError:
     pass
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -13,6 +13,11 @@ import base64
 import os
 import sys
 
+try:
+  import unzip_requirements
+except ImportError:
+  pass
+
 TEXT_MIME_TYPES = ['application/json', 'application/xml']
 
 import importlib  # noqa: E402


### PR DESCRIPTION
Hey, it is me again,

I ran into an issue while using zipping my dependencies using the python requirements plugin, as per their documentation we need to import a file created during the deploy process so we can use the zipped dependencies.

After getting tired of manually updating the wsgy.py on each deploy I decided to update my personal fork with the automated "solution" and open this PR so other people can benefit from that.

Cheers,

EM