### PR TITLE
remove specific AWS host

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -69,7 +69,11 @@ def handler(event, context):
 
     headers = Headers(event[u'headers'])
 
-    script_name = '/{}'.format(event[u'requestContext'].get(u'stage', ''))
+    host = headers.get(u'Host', u'')
+    if u".amazonaws" in host:
+        script_name = '/{}'.format(event[u'requestContext'].get(u'stage', ''))
+    else:
+        script_name = ''
 
     # If a user is using a custom domain on API Gateway, they may have a base
     # path in their URL. This allows us to strip it out via an optional

--- a/wsgi.py
+++ b/wsgi.py
@@ -69,10 +69,7 @@ def handler(event, context):
 
     headers = Headers(event[u'headers'])
 
-    if headers.get(u'Host', u'').endswith(u'.amazonaws.com'):
-        script_name = '/{}'.format(event[u'requestContext'].get(u'stage', ''))
-    else:
-        script_name = ''
+    script_name = '/{}'.format(event[u'requestContext'].get(u'stage', ''))
 
     # If a user is using a custom domain on API Gateway, they may have a base
     # path in their URL. This allows us to strip it out via an optional


### PR DESCRIPTION
For china AWS API Gateway is end with `.amzonaws.com.cn`.

I think better to remove the filter the host  on the specific url.