### PR TITLE
Add compatibility with serverless-offline

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,6 +272,17 @@ class ServerlessWSGI {
       'after:deploy:function:packageFunction': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.unlinkRequirements)
+        .then(this.cleanup),
+
+      'before:offline:start:init': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.packWsgiHandler)
+        .then(this.packRequirements)
+        .then(this.linkRequirements),
+
+      'after:offline:start:end': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.unlinkRequirements)
         .then(this.cleanup)
     };
   }

--- a/index.test.js
+++ b/index.test.js
@@ -26,6 +26,8 @@ describe('serverless-wsgi', () => {
       expect(plugin.hooks['before:package:createDeploymentArtifacts']).to.be.a('function');
       expect(plugin.hooks['after:package:createDeploymentArtifacts']).to.be.a('function');
       expect(plugin.hooks['wsgi:serve:serve']).to.be.a('function');
+      expect(plugin.hooks['before:offline:start:init']).to.be.a('function');
+      expect(plugin.hooks['after:offline:start:end']).to.be.a('function');
     });
   });
 


### PR DESCRIPTION
This PR adds hooks to build the wsgi handler in reaction to events defined by [`serverless-offline`](https://github.com/dherault/serverless-offline).

This will allow developers to use `serverless-wsgi` seamlessly (albeit w/ a performance hit) with `serverless-offline`. I'm open to suggestions on optimization.