### PR TITLE
Allow adding additional text mime types

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -25,6 +25,8 @@ TEXT_MIME_TYPES = [
     "application/vnd.api+json",
 ]
 
+TEXT_MIME_TYPES.extend(os.environ.get("ADDITIONAL_TEXT_MIME_TYPES", []))
+
 import importlib  # noqa: E402
 from werkzeug.datastructures import Headers  # noqa: E402
 from werkzeug.wrappers import Response  # noqa: E402


### PR DESCRIPTION
We were having issues similar to #48, however we're working with our own custom vendor types. This change allows us to specify additional mime types to be added to the list using an env var.