### PR TITLE
Import serverless_wsgi after unzipping requirements

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -10,7 +10,6 @@ import importlib
 import json
 import os
 import sys
-import serverless_wsgi
 
 # Call decompression helper from `serverless-python-requirements` if
 # available. See: https://github.com/UnitedIncome/serverless-python-requirements#dealing-with-lambdas-size-limitations
@@ -18,6 +17,8 @@ try:
     import unzip_requirements  # noqa
 except ImportError:
     pass
+
+import serverless_wsgi
 
 
 def load_config():


### PR DESCRIPTION
I think this may fix https://github.com/logandk/serverless-wsgi/issues/71.  I just ran into this as well.  I believe what is happening is the code is trying to import `serverless_wsgi` which then does these imports:

```
import base64
import os
import sys
from werkzeug.datastructures import Headers
from werkzeug.wrappers import Response
from werkzeug.urls import url_encode
from werkzeug._compat import BytesIO, string_types, to_bytes, wsgi_encoding_dance
```

and since werkzeug may still be zipped inside of `.requirements.zip`