### PR TITLE
Adding ALB Support

### DIFF
--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -132,6 +132,10 @@ def handle_request(app, event, context):
             mimetype.startswith("text/") or mimetype in TEXT_MIME_TYPES
         ) and not response.headers.get("Content-Encoding", ""):
             returndict["body"] = response.get_data(as_text=True)
+            if event.get("requestContext").get("elb"):  # If the request comes from the ELB we need to add those 2 fields to response
+                desc = {200: 'OK', 201: 'Created', 202: 'Accepted', 203: 'Non-Authoritative Information', 204: 'No Content', 205: 'Reset Content', 206: 'Partial Content', 400: 'Bad Request', 401: 'Unauthorized', 402: 'Payment Required', 403: 'Forbidden', 404: 'Not Found', 405: 'Method Not Allowed', 406: 'Not Acceptable', 407: 'Proxy Authentication Required', 408: 'Request Timeout', 409: 'Conflict', 410: 'Gone', 411: 'Length Required', 412: 'Precondition Failed', 413: 'Request Entity Too Large', 414: 'Request-URI Too Long', 415: 'Unsupported Media Type', 416: 'Requested Range Not Satisfiable', 417: 'Expectation Failed', 100: 'Continue', 101: 'Switching Protocols', 300: 'Multiple Choices', 301: 'Moved Permanently', 302: 'Found', 303: 'See Other', 304: 'Not Modified', 305: 'Use Proxy', 306: '(Unused)', 307: 'Temporary Redirect', 500: 'Internal Server Error', 501: 'Not Implemented', 502: 'Bad Gateway', 503: 'Service Unavailable', 504: 'Gateway Timeout', 505: 'HTTP Version Not Supported'}
+                returndict["isBase64Encoded"] = False
+                returndict["statusDescription"] = "%d %s" % (response.status_code, desc[response.status_code])
         else:
             returndict["body"] = base64.b64encode(response.data).decode("utf-8")
             returndict["isBase64Encoded"] = "true"


### PR DESCRIPTION
Adding Support for Flask Responses to output directly to an ALB 

Checked Here:
https://aws.amazon.com/pt/blogs/networking-and-content-delivery/lambda-functions-as-targets-for-application-load-balancers/

We need to add isBase64Encoded= False and the statusDescription to the Response in order to ALB to accepts it as a valid response and not give us 502.

The problem is that if we always add, Api Gateway complains and throws us an error :)

With this little code, everything works seamlessly without the user have the need to worry. It also supports Api Gateway + ALB (If someone want to do some endpoints in ALB directly to save some Api Gateway Requests)

Hope you enjoy