### PR TITLE
Spit traceback to stdout when error loading app

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -10,6 +10,7 @@ import importlib
 import json
 import os
 import sys
+import traceback
 
 # Call decompression helper from `serverless-python-requirements` if
 # available. See: https://github.com/UnitedIncome/serverless-python-requirements#dealing-with-lambdas-size-limitations
@@ -39,7 +40,10 @@ def import_app(config):
         root = os.path.abspath(os.path.dirname(__file__))
         sys.path.insert(0, os.path.join(root, wsgi_fqn_parts[0]))
 
-    wsgi_module = importlib.import_module(wsgi_fqn_parts[-1])
+    try:
+        wsgi_module = importlib.import_module(wsgi_fqn_parts[-1])
+    except:
+        print(traceback.format_exc())
 
     return getattr(wsgi_module, wsgi_fqn[1])
 
@@ -57,7 +61,6 @@ def handler(event, context):
     if "_serverless-wsgi" in event:
         import shlex
         import subprocess
-        import traceback
         from werkzeug._compat import StringIO, to_native
 
         native_stdout = sys.stdout

--- a/wsgi.py
+++ b/wsgi.py
@@ -42,7 +42,7 @@ def import_app(config):
 
     try:
         wsgi_module = importlib.import_module(wsgi_fqn_parts[-1])
-    except:
+    except:  # noqa
         print(traceback.format_exc())
 
     return getattr(wsgi_module, wsgi_fqn[1])


### PR DESCRIPTION
When loaded app. having error such as missing import or syntax error, then `sls logs -t -f function_name` doesn't give any clue at all.