### PR TITLE
Support multi-value parameters

### DIFF
--- a/wsgi_handler_test.py
+++ b/wsgi_handler_test.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import pytest
+from werkzeug.datastructures import MultiDict
 from werkzeug.wrappers import Request, Response
 from werkzeug.urls import url_encode
 
@@ -271,6 +272,14 @@ def test_handler(mock_wsgi_app_file, mock_app, event, capsys, wsgi_handler):
     out, err = capsys.readouterr()
     assert out == ""
     assert err == "application debug #1\n"
+
+
+def test_handler_multivalue(mock_wsgi_app_file, mock_app, event, capsys, wsgi_handler):
+    event["multiValueQueryStringParameters"] = {"param1": ["value1"], "param2": ["value2", "value3"]}
+    wsgi_handler.handler(event, {"memory_limit_in_mb": "128"})
+    query_string = wsgi_handler.wsgi_app.last_environ["QUERY_STRING"]
+
+    assert query_string == url_encode(MultiDict((i, k) for i, j in event["multiValueQueryStringParameters"].items() for k in j))
 
 
 def test_handler_china(mock_wsgi_app_file, mock_app, event, capsys, wsgi_handler):


### PR DESCRIPTION
Last November API Gateway added support for multi-value parameters:

https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/

This adds support for those. However, with ALB whether you get them depends on a target group attribute, so we have to also retain support the old queryStringParameters event field:

https://serverless-training.com/articles/api-gateway-vs-application-load-balancer-technical-details/

Note: the same should really be done to headers but I don't need it. Also, since WSGI seems to require concatenating the header values with semicolons, that might actually break someone's current code, so it may require more thought.