### PR TITLE
Call flaskgroup main, not app.cli.main 

### DIFF
--- a/wsgi_handler.py
+++ b/wsgi_handler.py
@@ -92,7 +92,7 @@ def handler(event, context):
                 from flask.cli import FlaskGroup
 
                 fg = FlaskGroup()
-                fg.main(shlex.split(meta.get("data", "")))
+                fg.main(shlex.split(meta.get("data", "")), standalone_mode=False)
             else:
                 raise Exception("Unknown command: {}".format(meta.get("command")))
         except:  # noqa

--- a/wsgi_handler.py
+++ b/wsgi_handler.py
@@ -92,7 +92,7 @@ def handler(event, context):
                 from flask.cli import FlaskGroup
 
                 fg = FlaskGroup()
-                fg.main(shlex.split(meta.get("data", "")), standalone_mode=False)
+                fg.main(shlex.split(meta.get("data", "")))
             else:
                 raise Exception("Unknown command: {}".format(meta.get("command")))
         except:  # noqa

--- a/wsgi_handler.py
+++ b/wsgi_handler.py
@@ -89,13 +89,10 @@ def handler(event, context):
                 management.call_command(*shlex.split(meta.get("data", "")))
             elif meta.get("command") == "flask":
                 # Run Flask CLI commands
-                from flask.cli import ScriptInfo
+                from flask.cli import FlaskGroup
 
-                wsgi_app.cli.main(
-                    shlex.split(meta.get("data", "")),
-                    standalone_mode=False,
-                    obj=ScriptInfo(create_app=_create_app),
-                )
+                fg = FlaskGroup()
+                fg.main(shlex.split(meta.get("data", "")), standalone_mode=False)
             else:
                 raise Exception("Unknown command: {}".format(meta.get("command")))
         except:  # noqa
@@ -107,10 +104,6 @@ def handler(event, context):
         return output_buffer.getvalue()
     else:
         return serverless_wsgi.handle_request(wsgi_app, event, context)
-
-
-def _create_app():
-    return wsgi_app
 
 
 # Read configuration and import the WSGI application

--- a/wsgi_handler_test.py
+++ b/wsgi_handler_test.py
@@ -698,7 +698,8 @@ def test_command_flask(mock_wsgi_app_file, mock_app, wsgi_handler):
                 self.__dict__[k] = v
 
     class MockFlaskGroup:
-        def main(ctx, args):
+        def main(ctx, args, standalone_mode):
+            assert not standalone_mode
             print("Called with: {}".format(", ".join(args)))
 
     sys.modules["flask"] = MockObject()

--- a/wsgi_handler_test.py
+++ b/wsgi_handler_test.py
@@ -15,12 +15,12 @@ import pytest
 from werkzeug.datastructures import MultiDict
 from werkzeug.wrappers import Request, Response
 from werkzeug.urls import url_encode
+from unittest.mock import MagicMock
 
 PY2 = sys.version_info[0] == 2
 
 # Reference to open() before monkeypatching
 original_open = open
-
 
 # This workaround is needed for coverage.py to pick up the wsgi handler module
 try:
@@ -697,16 +697,12 @@ def test_command_flask(mock_wsgi_app_file, mock_app, wsgi_handler):
             for k, v in kwargs.items():
                 self.__dict__[k] = v
 
-    class MockFlaskCli:
-        def main(ctx, args, standalone_mode, obj):
-            assert not standalone_mode
-            assert obj.create_app() == mock_app
+    class MockFlaskGroup:
+        def main(ctx, args):
             print("Called with: {}".format(", ".join(args)))
 
     sys.modules["flask"] = MockObject()
-    sys.modules["flask.cli"] = MockObject()
-    sys.modules["flask.cli"].ScriptInfo = MockObject
-    mock_app.cli = MockFlaskCli()
+    sys.modules["flask.cli"] = MockObject(FlaskGroup=MockFlaskGroup)
 
     response = wsgi_handler.handler(
         {"_serverless-wsgi": {"command": "flask", "data": "custom command"}}, {}


### PR DESCRIPTION
Because app.cli.main is replaced by click.core.main (I don't know why)