### PR TITLE
Made threading optional and added support for multi-process mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -385,16 +385,28 @@ class ServerlessWSGI {
 
       const port = this.options.port || 5000;
       const host = this.options.host || "localhost";
+      const disable_threading = this.options["disable-threading"] || false;
+      const num_processes = this.options["num-processes"] || 1;
+
+      var args = [
+        path.resolve(__dirname, "serve.py"),
+        this.serverless.config.servicePath,
+        this.wsgiApp,
+        port,
+        host,
+      ];
+
+      if (num_processes > 1) {
+        args.push("--num-processes", num_processes);
+      }
+
+      if(disable_threading) {
+        args.push("--disable-threading");
+      }
 
       var status = child_process.spawnSync(
         this.pythonBin,
-        [
-          path.resolve(__dirname, "serve.py"),
-          this.serverless.config.servicePath,
-          this.wsgiApp,
-          port,
-          host
-        ],
+        args,
         { stdio: "inherit" }
       );
       if (status.error) {
@@ -541,7 +553,13 @@ class ServerlessWSGI {
               },
               host: {
                 usage: "Server host, defaults to 'localhost'"
-              }
+              },
+              "disable-threading": {
+                usage: "Disables multi-threaded mode"
+              },
+              "num-processes": {
+                usage: "Number of processes for server, defaults to 1"
+              },
             }
           },
           install: {

--- a/serve_test.py
+++ b/serve_test.py
@@ -60,6 +60,7 @@ def test_serve(mock_path, mock_importlib, mock_werkzeug):
         "use_debugger": True,
         "use_evalex": True,
         "threaded": True,
+        "processes": 1,
     }
 
 
@@ -76,7 +77,42 @@ def test_serve_alternative_hostname(mock_path, mock_importlib, mock_werkzeug):
         "use_debugger": True,
         "use_evalex": True,
         "threaded": True,
+        "processes": 1,
     }
+
+
+def test_serve_disable_threading(mock_path, mock_importlib, mock_werkzeug):
+    serve.serve("/tmp1", "app.app", "5000", "0.0.0.0", threaded=False)
+    assert len(mock_path) == 1
+    assert mock_path[0] == "/tmp1"
+    assert mock_werkzeug.lastcall.host == "0.0.0.0"
+    assert mock_werkzeug.lastcall.port == 5000
+    assert mock_werkzeug.lastcall.app.module == "app"
+    assert mock_werkzeug.lastcall.app.debug
+    assert mock_werkzeug.lastcall.kwargs == {
+        "use_reloader": True,
+        "use_debugger": True,
+        "use_evalex": True,
+        "threaded": False,
+        "processes": 1,
+    }
+
+
+def test_serve_multiple_processes(mock_path, mock_importlib, mock_werkzeug):
+        serve.serve("/tmp1", "app.app", "5000", "0.0.0.0", processes=10)
+        assert len(mock_path) == 1
+        assert mock_path[0] == "/tmp1"
+        assert mock_werkzeug.lastcall.host == "0.0.0.0"
+        assert mock_werkzeug.lastcall.port == 5000
+        assert mock_werkzeug.lastcall.app.module == "app"
+        assert mock_werkzeug.lastcall.app.debug
+        assert mock_werkzeug.lastcall.kwargs == {
+            "use_reloader": True,
+            "use_debugger": True,
+            "use_evalex": True,
+            "threaded": True,
+            "processes": 10,
+        }
 
 
 def test_serve_from_subdir(mock_path, mock_importlib, mock_werkzeug):
@@ -93,6 +129,7 @@ def test_serve_from_subdir(mock_path, mock_importlib, mock_werkzeug):
         "use_debugger": True,
         "use_evalex": True,
         "threaded": True,
+        "processes": 1,
     }
 
 


### PR DESCRIPTION
## What
Updated the `serve` capabilities to allow for optionally running in multi-process mode and/or disabling threading. The default behavior was kept the same, where threading is enabled and the server uses a single process.

## Why
To optionally support a concurrency model that resembles that of API Gateway + Lambdas (where each request is routed to a separated Lambda container/instance) during local development.

## Testing
* `pytest serve_test.py` tests pass
* `npm test` tests pass
* Was able to run a test project with threading and multi-process flags/options passed, verifying serialized and concurrent request handling when serving 100+ requests at once.

## Failing Tests
At the time of making this PR, the `master` branch has failing tests in `wsgi_handler_test.py`. Source: https://travis-ci.org/logandk/serverless-wsgi/jobs/546463386
