### PR TITLE
Allow use of CloudFront with a pre-set path

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,26 @@ custom:
     createRoute53Record: true
 ```
 
+### Using CloudFront
+
+If you're configuring CloudFront manually in front of your API and setting
+the Path in the CloudFront Origin to include your stage name, you'll need
+to strip it out from the path supplied to WSGI. This is so that your app
+doesn't generate URLs starting with `/production`.
+
+Pass the `STRIP_STAGE_PATH=yes` environment variable to your application
+to set this:
+
+```yaml
+service: example
+
+provider:
+  name: aws
+  runtime: python3.6
+  environment:
+    STRIP_STAGE_PATH: yes
+```
+
 ### File uploads
 
 In order to accept file uploads from HTML forms, make sure to add `multipart/form-data` to

--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -93,7 +93,7 @@ def handle_request(app, event, context):
     else:
         headers = Headers(event[u"headers"])
 
-    if u"amazonaws.com" in headers.get(u"Host", u""):
+    if os.environ.get("STRIP_STAGE_PATH", "") != "yes" and u"amazonaws.com" in headers.get(u"Host", u""):
         script_name = "/{}".format(event[u"requestContext"].get(u"stage", ""))
     else:
         script_name = ""


### PR DESCRIPTION
When using CloudFront manually with the Origin set to the exact stage
URL, the WSGI application thinks that it is mounted at `/${stage}`
rather than `/`. This causes it to generate and return invalid URLs to
the user.

Example:
A CF distribution for `example.com` pointing at
`0deadbeef.execute-api.eu-west-1.amazonaws.com/production` should think
that `/foo` is mounted at `https://example.com/foo` not
`https://example.com/production/foo`

We need to fix this behaviour due to the assumption that all requests
with `amazonaws.com` in the Host header will contain the stage name in
the path. This is not true for CloudFront as it will send the `Host`
header of the origin, triggering our `if` clause.