### PR TITLE
Improve API_GATEWAY_BASE_PATH documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ custom:
 If you use custom domain names with API Gateway, you might have a base path that is
 at the beginning of your path, such as the stage (`/dev`, `/stage`, `/prod`). In this case, set
 the `API_GATEWAY_BASE_PATH` environment variable to let `serverless-wsgi` know.
+E.g, if you deploy your WSGI application to https://mydomain.com/api/myservice,
+set `API_GATEWAY_BASE_PATH` to `api/myservice` (no `/` first).
 
 The example below uses the [serverless-domain-manager](https://github.com/amplify-education/serverless-domain-manager)
 plugin to handle custom domains in API Gateway:


### PR DESCRIPTION
Hi there,

Just spend a significant amount of time trying to deploy a WSGI application to our production API. However, it was not until I inspected the source code I figured out what exactly to put in the `API_GATEWAY_BASE_PATH` variable. I had a `/` first which caused the issue.

One could also consider battle-hardening the actual logic (https://github.com/logandk/serverless-wsgi/blob/master/serverless_wsgi.py#L113-L118) but I have not looked into that.

Either way, super excited about the WSGI plugin. Now I can run my Flask application everywhere!