### PR TITLE
Read stderr in utf8 so error messages are printed correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ class ServerlessWSGI {
 
       this.serverless.cli.log("Packaging required Python packages...");
 
-      const res = child_process.spawnSync(this.pythonBin, args);
+      const res = child_process.spawnSync(this.pythonBin, args, {'encoding': 'utf8'});
       if (res.error) {
         if (res.error.code == "ENOENT") {
           return reject(


### PR DESCRIPTION
Errors from packaging requirements are dumped in hex values because child_process defaults to using a Buffer class, which serverless does not know to handle.

Using encoding option returns a string that makes sense to the user. E.g. (without virtualenv installed):

```
Serverless: Using Python specified in "runtime": python3.8
Serverless: Packaging Python WSGI handler...
Serverless: Packaging required Python packages...
 
 Exception -----------------------------------------------
 
  <Buffer 55 6e 61 62 6c 65 20 74 6f 20 6c 6f 61 64 20 76 69 72 74 75 61 6c 65 6e 76 2c 20 70 6c 65 61 73 65 20 69 6e 73 74 61 6c 6c 0a>
```

Turns into:

```
Serverless: Using Python specified in "runtime": python3.8
Serverless: Packaging Python WSGI handler...
Serverless: Packaging required Python packages...
 
 Exception -----------------------------------------------
 
  'Unable to load virtualenv, please install\n'
```

This should fix #122