### PR TITLE
Fix the ALB query parameter handling.

### DIFF
--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -76,7 +76,7 @@ def group_headers(headers):
 
 
 def encode_query_string(event, from_alb):
-    params = event.get(u"multiValueQueryStringParameters") or event.get(u"queryStringParameters")
+    params = event.get(u"multiValueQueryStringParameters") or event.get(u"queryStringParameters", {})
     if from_alb:
         params = MultiDict(
             (url_unquote(k), url_unquote(v)) for k, v in iter_multi_items(params)

--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -76,7 +76,7 @@ def group_headers(headers):
 
 
 def encode_query_string(event, from_alb):
-    params = event.get(u"multiValueQueryStringParameters") or event.get(u"queryStringParameters", {})
+    params = event.get(u"multiValueQueryStringParameters") or event.get(u"queryStringParameters") or {}
     if from_alb:
         params = MultiDict(
             (url_unquote(k), url_unquote(v)) for k, v in iter_multi_items(params)

--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -12,7 +12,7 @@ import os
 import sys
 from werkzeug.datastructures import Headers, iter_multi_items, MultiDict
 from werkzeug.wrappers import Response
-from werkzeug.urls import url_encode, url_unquote
+from werkzeug.urls import url_encode, url_unquote, url_unquote_plus
 from werkzeug.http import HTTP_STATUS_CODES
 from werkzeug._compat import BytesIO, string_types, to_bytes, wsgi_encoding_dance
 
@@ -79,7 +79,7 @@ def encode_query_string(event, from_alb):
     params = event.get(u"multiValueQueryStringParameters") or event.get(u"queryStringParameters") or {}
     if from_alb:
         params = MultiDict(
-            (url_unquote(k), url_unquote(v)) for k, v in iter_multi_items(params)
+            (url_unquote_plus(k), url_unquote_plus(v)) for k, v in iter_multi_items(params)
         )
     return url_encode(params)
 

--- a/wsgi_handler_test.py
+++ b/wsgi_handler_test.py
@@ -667,12 +667,12 @@ def test_handler_alb(mock_wsgi_app_file, mock_app, wsgi_handler, elb_event):
 
 
 def test_alb_query_params(mock_wsgi_app_file, mock_app, wsgi_handler, elb_event):
-    elb_event['queryStringParameters'] = {
-        'test': 'test%20test'
+    elb_event["queryStringParameters"] = {
+        "test": "test%20test"
     }
     response = wsgi_handler.handler(elb_event, {})
     query_string = wsgi_handler.wsgi_app.last_environ["QUERY_STRING"]
-    assert query_string == 'test=test+test'
+    assert query_string == "test=test+test"
 
     assert response == {
         "body": u"Hello World ☃!",
@@ -690,14 +690,17 @@ def test_alb_query_params(mock_wsgi_app_file, mock_app, wsgi_handler, elb_event)
 
 
 def test_alb_multi_query_params(mock_wsgi_app_file, mock_app, wsgi_handler, elb_event):
-    del(elb_event['queryStringParameters'])
-    elb_event['multiValueQueryStringParameters'] = {
-        '%E6%B8%AC%E8%A9%A6': ['%E3%83%86%E3%82%B9%E3%83%88', 'test'],
-        'test': 'test%20test'
+    del(elb_event["queryStringParameters"])
+    elb_event["multiValueQueryStringParameters"] = {
+        "%E6%B8%AC%E8%A9%A6": ["%E3%83%86%E3%82%B9%E3%83%88", "test"],
+        "test": "test%20test"
     }
     response = wsgi_handler.handler(elb_event, {})
     query_string = wsgi_handler.wsgi_app.last_environ["QUERY_STRING"]
-    assert query_string == 'test=test+test&%E6%B8%AC%E8%A9%A6=%E3%83%86%E3%82%B9%E3%83%88&%E6%B8%AC%E8%A9%A6=test'
+    assert query_string == url_encode({
+        "測試": ["テスト", "test"],
+        "test": "test test"
+    })
 
     assert response == {
         "body": u"Hello World ☃!",


### PR DESCRIPTION
This pull request addresses the query parameter issue we hit on using it with ALB. As mentioned in official document:
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html

> If the query parameters are URL-encoded, the load balancer does not decode them. You must decode them in your Lambda function. 

See also:
https://github.com/brefphp/bref/issues/456

This PR will decode query parameters correctly if the request is from ALB, regardless multi value support is enabled. This will fix query parameters with space (will be encoded to `%20`) and Unicode in ALB.

Also, `url_encode` in should natively support iteration on the `multiValueQueryStringParameters` since Werkzeug 0.3, so I remove the unnecessary `MultiDict` construction.

Also added tests for them.

(I am testing them in our instance before the review, so I made it a draft for now)