### PR TITLE
Support for the new HTTP API lambda proxy resp. Payload v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ http://wsgi.readthedocs.io/en/latest/frameworks.html.
 - Automatically downloads Python packages that you specify in `requirements.txt` and deploys them along with your application
 - Convenient `wsgi serve` command for serving your application locally during development
 - Includes CLI commands for remote execution of Python code (`wsgi exec`), shell commands (`wsgi command`), Flask CLI commands (`wsgi flask`) and Django management commands (`wsgi manage`)
+- Supports both APIGatewayV1 and APIGatewayV2 payloads
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ custom:
     createRoute53Record: true
 ```
 
+**Note**: The **API_GATEWAY_BASE_PATH** configuration is only needed when using the payload V1. In the V2, the path does not have the **basePath** in the beginning.
 ### Using CloudFront
 
 If you're configuring CloudFront manually in front of your API and setting

--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -187,11 +187,11 @@ def handle_payload_v1(app, event, context):
         "PATH_INFO": url_unquote(path_info),
         "QUERY_STRING": encode_query_string(event),
         "REMOTE_ADDR": event[u"requestContext"]
-            .get(u"identity", {})
-            .get(u"sourceIp", ""),
+        .get(u"identity", {})
+        .get(u"sourceIp", ""),
         "REMOTE_USER": event[u"requestContext"]
-            .get(u"authorizer", {})
-            .get(u"principalId", ""),
+        .get(u"authorizer", {})
+        .get(u"principalId", ""),
         "REQUEST_METHOD": event[u"httpMethod"],
         "SCRIPT_NAME": script_name,
         "SERVER_NAME": headers.get(u"Host", "lambda"),
@@ -245,14 +245,14 @@ def handle_payload_v2(app, event, context):
         "PATH_INFO": url_unquote(path_info),
         "QUERY_STRING": url_encode(event.get(u"queryStringParameters", {})),
         "REMOTE_ADDR": event[u"requestContext"]
-            .get(u"http", {})
-            .get(u"sourceIp", ""),
+        .get(u"http", {})
+        .get(u"sourceIp", ""),
         "REMOTE_USER": event[u"requestContext"]
-            .get(u"authorizer", {})
-            .get(u"principalId", ""),
+        .get(u"authorizer", {})
+        .get(u"principalId", ""),
         "REQUEST_METHOD": event[u"requestContext"]
-            .get("http", {})
-            .get("method", ""),
+        .get("http", {})
+        .get("method", ""),
         "SCRIPT_NAME": script_name,
         "SERVER_NAME": headers.get(u"Host", "lambda"),
         "SERVER_PORT": headers.get(u"X-Forwarded-Port", "80"),

--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -83,19 +83,7 @@ def encode_query_string(event):
         return url_encode(event.get(u"queryStringParameters") or {})
 
 
-def handle_request(app, event, context):
-    if event.get("source") in ["aws.events", "serverless-plugin-warmup"]:
-        print("Lambda warming event received, skipping handler")
-        return {}
-
-    if event.get("version") == "2.0":
-        return handle_payload_v2(app, event, context)
-
-    if u"multiValueHeaders" in event:
-        headers = Headers(event[u"multiValueHeaders"])
-    else:
-        headers = Headers(event[u"headers"])
-
+def get_script_name(headers, request_context):
     strip_stage_path = os.environ.get("STRIP_STAGE_PATH", "").lower().strip() in [
         "yes",
         "y",
@@ -105,9 +93,79 @@ def handle_request(app, event, context):
     ]
 
     if u"amazonaws.com" in headers.get(u"Host", u"") and not strip_stage_path:
-        script_name = "/{}".format(event[u"requestContext"].get(u"stage", ""))
+        script_name = "/{}".format(request_context.get(u"stage", ""))
     else:
         script_name = ""
+    return script_name
+
+
+def get_body_bytes(event, body):
+    if event.get("isBase64Encoded", False):
+        body = base64.b64decode(body)
+    if isinstance(body, string_types):
+        body = to_bytes(body, charset="utf-8")
+    return body
+
+
+def setup_environ_items(environ, headers):
+    for key, value in environ.items():
+        if isinstance(value, string_types):
+            environ[key] = wsgi_encoding_dance(value)
+
+    for key, value in headers.items():
+        key = "HTTP_" + key.upper().replace("-", "_")
+        if key not in ("HTTP_CONTENT_TYPE", "HTTP_CONTENT_LENGTH"):
+            environ[key] = value
+    return environ
+
+
+def generate_response(response, event):
+    returndict = {u"statusCode": response.status_code}
+
+    if u"multiValueHeaders" in event:
+        returndict[u"multiValueHeaders"] = group_headers(response.headers)
+    else:
+        returndict[u"headers"] = split_headers(response.headers)
+
+    if event.get("requestContext").get("elb"):
+        # If the request comes from ALB we need to add a status description
+        returndict["statusDescription"] = u"%d %s" % (
+            response.status_code,
+            HTTP_STATUS_CODES[response.status_code],
+        )
+
+    if response.data:
+        mimetype = response.mimetype or "text/plain"
+        if (
+                mimetype.startswith("text/") or mimetype in TEXT_MIME_TYPES
+        ) and not response.headers.get("Content-Encoding", ""):
+            returndict["body"] = response.get_data(as_text=True)
+            returndict["isBase64Encoded"] = False
+        else:
+            returndict["body"] = base64.b64encode(response.data).decode("utf-8")
+            returndict["isBase64Encoded"] = True
+
+    return returndict
+
+
+def handle_request(app, event, context):
+    if event.get("source") in ["aws.events", "serverless-plugin-warmup"]:
+        print("Lambda warming event received, skipping handler")
+        return {}
+
+    if event.get("version") == "2.0":
+        return handle_payload_v2(app, event, context)
+
+    return handle_payload_v1(app, event, context)
+
+
+def handle_payload_v1(app, event, context):
+    if u"multiValueHeaders" in event:
+        headers = Headers(event[u"multiValueHeaders"])
+    else:
+        headers = Headers(event[u"headers"])
+
+    script_name = get_script_name(headers, event[u"requestContext"])
 
     # If a user is using a custom domain on API Gateway, they may have a base
     # path in their URL. This allows us to strip it out via an optional
@@ -118,13 +176,10 @@ def handle_request(app, event, context):
         script_name = "/" + base_path
 
         if path_info.startswith(script_name):
-            path_info = path_info[len(script_name) :]
+            path_info = path_info[len(script_name):]
 
     body = event[u"body"] or ""
-    if event.get("isBase64Encoded", False):
-        body = base64.b64decode(body)
-    if isinstance(body, string_types):
-        body = to_bytes(body, charset="utf-8")
+    body = get_body_bytes(event, body)
 
     environ = {
         "CONTENT_LENGTH": str(len(body)),
@@ -132,11 +187,11 @@ def handle_request(app, event, context):
         "PATH_INFO": url_unquote(path_info),
         "QUERY_STRING": encode_query_string(event),
         "REMOTE_ADDR": event[u"requestContext"]
-        .get(u"identity", {})
-        .get(u"sourceIp", ""),
+            .get(u"identity", {})
+            .get(u"sourceIp", ""),
         "REMOTE_USER": event[u"requestContext"]
-        .get(u"authorizer", {})
-        .get(u"principalId", ""),
+            .get(u"authorizer", {})
+            .get(u"principalId", ""),
         "REQUEST_METHOD": event[u"httpMethod"],
         "SCRIPT_NAME": script_name,
         "SERVER_NAME": headers.get(u"Host", "lambda"),
@@ -164,66 +219,25 @@ def handle_request(app, event, context):
         "context": context,
     }
 
-    for key, value in environ.items():
-        if isinstance(value, string_types):
-            environ[key] = wsgi_encoding_dance(value)
-
-    for key, value in headers.items():
-        key = "HTTP_" + key.upper().replace("-", "_")
-        if key not in ("HTTP_CONTENT_TYPE", "HTTP_CONTENT_LENGTH"):
-            environ[key] = value
+    environ = setup_environ_items(environ, headers)
 
     response = Response.from_app(app, environ)
-
-    returndict = {u"statusCode": response.status_code}
-
-    if u"multiValueHeaders" in event:
-        returndict[u"multiValueHeaders"] = group_headers(response.headers)
-    else:
-        returndict[u"headers"] = split_headers(response.headers)
-
-    if event.get("requestContext").get("elb"):
-        # If the request comes from ALB we need to add a status description
-        returndict["statusDescription"] = u"%d %s" % (
-            response.status_code,
-            HTTP_STATUS_CODES[response.status_code],
-        )
-
-    if response.data:
-        mimetype = response.mimetype or "text/plain"
-        if (
-            mimetype.startswith("text/") or mimetype in TEXT_MIME_TYPES
-        ) and not response.headers.get("Content-Encoding", ""):
-            returndict["body"] = response.get_data(as_text=True)
-            returndict["isBase64Encoded"] = False
-        else:
-            returndict["body"] = base64.b64encode(response.data).decode("utf-8")
-            returndict["isBase64Encoded"] = True
+    returndict = generate_response(response, event)
 
     return returndict
 
+
 def handle_payload_v2(app, event, context):
     headers = Headers(event[u"headers"])
-    strip_stage_path = os.environ.get("STRIP_STAGE_PATH", "").lower().strip() in [
-        "yes",
-        "y",
-        "true",
-        "t",
-        "1",
-    ]
 
-    if u"amazonaws.com" in headers.get(u"Host", u"") and not strip_stage_path:
-        script_name = "/{}".format(event[u"requestContext"].get(u"stage", ""))
-    else:
-        script_name = ""
+    script_name = get_script_name(headers, event[u"requestContext"])
 
     path_info = event[u"rawPath"]
 
     body = event.get("body", "")
-    if event.get("isBase64Encoded", False):
-        body = base64.b64decode(body)
-    if isinstance(body, string_types):
-        body = to_bytes(body, charset="utf-8")
+    body = get_body_bytes(event, body)
+
+    headers["Cookie"] = "; ".join(event.get("cookies", []))
 
     environ = {
         "CONTENT_LENGTH": str(len(body)),
@@ -265,37 +279,10 @@ def handle_payload_v2(app, event, context):
         "context": context,
     }
 
-    for key, value in environ.items():
-        if isinstance(value, string_types):
-            environ[key] = wsgi_encoding_dance(value)
-
-    for key, value in headers.items():
-        key = "HTTP_" + key.upper().replace("-", "_")
-        if key not in ("HTTP_CONTENT_TYPE", "HTTP_CONTENT_LENGTH"):
-            environ[key] = value
+    environ = setup_environ_items(environ, headers)
 
     response = Response.from_app(app, environ)
 
-    returndict = {u"statusCode": response.status_code}
-
-    returndict[u"headers"] = split_headers(response.headers)
-
-    if event.get("requestContext").get("elb"):
-        # If the request comes from ALB we need to add a status description
-        returndict["statusDescription"] = u"%d %s" % (
-            response.status_code,
-            HTTP_STATUS_CODES[response.status_code],
-        )
-
-    if response.data:
-        mimetype = response.mimetype or "text/plain"
-        if (
-                mimetype.startswith("text/") or mimetype in TEXT_MIME_TYPES
-        ) and not response.headers.get("Content-Encoding", ""):
-            returndict["body"] = response.get_data(as_text=True)
-            returndict["isBase64Encoded"] = False
-        else:
-            returndict["body"] = base64.b64encode(response.data).decode("utf-8")
-            returndict["isBase64Encoded"] = True
+    returndict = generate_response(response, event)
 
     return returndict

--- a/wsgi_handler_test.py
+++ b/wsgi_handler_test.py
@@ -855,7 +855,7 @@ def test_handler_v2(mock_wsgi_app_file, mock_app, event_v2, capsys, wsgi_handler
         "HTTP_CLOUDFRONT_IS_SMARTTV_VIEWER": "false",
         "HTTP_CLOUDFRONT_IS_TABLET_VIEWER": "false",
         "HTTP_CLOUDFRONT_VIEWER_COUNTRY": "DK",
-        #"HTTP_COOKIE": "CUSTOMER=WILE_E_COYOTE; PART_NUMBER=ROCKET_LAUNCHER_0001",
+        "HTTP_COOKIE": "CUSTOMER=WILE_E_COYOTE; PART_NUMBER=ROCKET_LAUNCHER_0001",
         "HTTP_HOST": "3z6kd9fbb1.execute-api.us-east-1.amazonaws.com",
         "HTTP_POSTMAN_TOKEN": "778a706e-d6b0-48d5-94dd-9e98c22f12fe",
         "HTTP_USER_AGENT": "PostmanRuntime/3.0.11-hotfix.2",

--- a/wsgi_handler_test.py
+++ b/wsgi_handler_test.py
@@ -893,3 +893,10 @@ def test_handler_v2(mock_wsgi_app_file, mock_app, event_v2, capsys, wsgi_handler
     assert out == ""
     assert err == "application debug #1\n"
 
+
+def test_handler_with_encoded_characters_in_path_v2(
+        mock_wsgi_app_file, mock_app, event_v2, capsys, wsgi_handler
+):
+    event_v2["rawPath"] = "/city/new%20york"
+    wsgi_handler.handler(event_v2, {"memory_limit_in_mb": "128"})
+    assert wsgi_handler.wsgi_app.last_environ["PATH_INFO"] == "/city/new york"


### PR DESCRIPTION
This pull request provides support for the new HTTP API lambda proxy resp. Payload v2.0. 

As mentioned in the official document: 
https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html