### PR TITLE
Pin werkzeug to v1.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-werkzeug
+werkzeug==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/logandk/serverless-wsgi",
     py_modules=["serverless_wsgi"],
-    install_requires=["werkzeug"],
+    install_requires=["werkzeug==1.0.1"],
     classifiers=(
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
In Werkzeug's [latest 2.0.0 release](https://werkzeug.palletsprojects.com/en/2.0.x/changes/#version-2-0-0), support for Python 2 was removed: https://github.com/pallets/werkzeug/pull/1693.

This means that the imports from `werkzeug._compat` in `serverless_wsgi.py` no longer work:
https://github.com/logandk/serverless-wsgi/blob/a1a1c557a9d81ed37cbfb089adc897ec760e78fb/serverless_wsgi.py#L18

This can be fixed by pinning the `werkzeug` dependency to a pre-v2.0.0 version until support for the `werkzeug._compat` module is no longer necessary.