### PR TITLE
apigateway-v2-payload - Fix handling multiple query parameters.

### DIFF
--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -259,7 +259,7 @@ def handle_payload_v2(app, event, context):
         "CONTENT_LENGTH": str(len(body)),
         "CONTENT_TYPE": headers.get(u"Content-Type", ""),
         "PATH_INFO": url_unquote(path_info),
-        "QUERY_STRING": url_encode(event.get(u"queryStringParameters", {})),
+        "QUERY_STRING": event.get("rawQueryString", ""),
         "REMOTE_ADDR": event.get("requestContext", {})
         .get(u"http", {})
         .get(u"sourceIp", ""),

--- a/wsgi_handler_test.py
+++ b/wsgi_handler_test.py
@@ -856,7 +856,7 @@ def event_v2():
             "X-Forwarded-Proto": "https",
             "cache-control": "no-cache",
         },
-        "queryStringParameters": {"param1": "value1", "param2": "value2, value3"},
+        "queryStringParameters": {"param1": "value1", "param2": "value2,value3"},
         "requestContext": {
             "accountId": "16794",
             "apiId": "3z6kd9fbb1",
@@ -921,7 +921,7 @@ def test_handler_v2(mock_wsgi_app_file, mock_app, event_v2, capsys, wsgi_handler
         "HTTP_X_FORWARDED_PORT": "443",
         "HTTP_X_FORWARDED_PROTO": "https",
         "PATH_INFO": "/some/path",
-        "QUERY_STRING": url_encode(event_v2["queryStringParameters"]),
+        "QUERY_STRING": "param1=value1&param2=value2&param2=value3",
         "REMOTE_ADDR": "76.20.166.147",
         "REMOTE_USER": "wile_e_coyote",
         "REQUEST_METHOD": "GET",


### PR DESCRIPTION
To accept multiple query parameters in HTTP API Payload V2 , simply use "rawQueryString".
https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html