### PR TITLE
Updated conditional check for isBase64Encoded to handle False

### DIFF
--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -166,7 +166,7 @@ def handle_request(app, event, context):
         print("Lambda warming event received, skipping handler")
         return {}
 
-    if event.get("version") is None and event.get("isBase64Encoded") is None:
+    if event.get("version") is None and not event.get("isBase64Encoded"):
         return handle_lambda_integration(app, event, context)
 
     if event.get("version") == "2.0":


### PR DESCRIPTION
This PR is intended to address #184 

When the isBase64Encoded parameter is set to False, then the conditional check on line 169 will evaluate to False and False != None. The change ensures that the conditional will evaluate to True when the value is set to None or False. 