### PR TITLE
Remove confusing version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Dependency Status](https://david-dm.org/logandk/serverless-wsgi.svg)](https://david-dm.org/logandk/serverless-wsgi)
 [![Dev Dependency Status](https://david-dm.org/logandk/serverless-wsgi/dev-status.svg)](https://david-dm.org/logandk/serverless-wsgi?type=dev)
 
-A Serverless v1.x plugin to build your deploy Python WSGI applications using Serverless. Compatible
+A Serverless Framework plugin to build your deploy Python WSGI applications using Serverless. Compatible
 WSGI application frameworks include Flask, Django and Pyramid - for a complete list, see:
 http://wsgi.readthedocs.io/en/latest/frameworks.html.
 


### PR DESCRIPTION
Serverless Framework is at v2 and soon will be at v3, and afaik this plugin will remain supporting it well.

I've remove confusing version info from documentation