### PR TITLE
Dropping support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-werkzeug==1.0.1
+werkzeug>2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="serverless-wsgi",
-    version="1.7.8",
+    version="2.0.0",
     author="Logan Raarup",
     author_email="logan@logan.dk",
     description="Amazon AWS API Gateway WSGI wrapper",
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/logandk/serverless-wsgi",
     py_modules=["serverless_wsgi"],
-    install_requires=["werkzeug==1.0.1"],
+    install_requires=["werkzeug>2"],
     classifiers=(
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
Resolves #179

Dropping support for Python 2, updating werkzeug version to >2, and version bumping this package to 2.0. This should resolve any compatibility issues with werkzeug <2. Tested working in my private AWS account.