### PR TITLE
Fixing serverless-wsgi to work on >=2.32

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,7 +441,7 @@ class ServerlessWSGI {
     // to match those of an invoke call.
     this.serverless.pluginManager.cliOptions.function = handlerFunction;
     this.options.function = handlerFunction;
-    this.serverless.pluginManager.cliOptions.data = JSON.stringify({
+    this.options.data = JSON.stringify({
       "_serverless-wsgi": {
         command: command,
         data: data,

--- a/index.js
+++ b/index.js
@@ -440,6 +440,7 @@ class ServerlessWSGI {
     // no proper plugin-facing API. Instead, the current CLI options are modified
     // to match those of an invoke call.
     this.serverless.pluginManager.cliOptions.function = handlerFunction;
+    this.options.function = handlerFunction;
     this.serverless.pluginManager.cliOptions.data = JSON.stringify({
       "_serverless-wsgi": {
         command: command,

--- a/index.js
+++ b/index.js
@@ -447,10 +447,22 @@ class ServerlessWSGI {
         data: data,
       },
     });
+    this.serverless.pluginManager.cliOptions.data = JSON.stringify({
+      "_serverless-wsgi": {
+        command: command,
+        data: data,
+      },
+    });
+
     this.serverless.pluginManager.cliOptions.context = undefined;
     this.serverless.pluginManager.cliOptions.f = this.serverless.pluginManager.cliOptions.function;
     this.serverless.pluginManager.cliOptions.d = this.serverless.pluginManager.cliOptions.data;
     this.serverless.pluginManager.cliOptions.c = this.serverless.pluginManager.cliOptions.context;
+    this.options.context = undefined;
+    this.options.f = this.options.function;
+    this.options.d = this.options.data;
+    this.options.c = this.options.context;
+
 
     // The invoke plugin prints the response to the console as JSON. When invoking commands
     // remotely, we get a string back and we want it to appear in the console as it would have

--- a/index.test.js
+++ b/index.test.js
@@ -1566,13 +1566,13 @@ describe("serverless-wsgi", () => {
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"exec","data":"print(1+4)"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"exec","data":"print(1+4)"}}'
         );
         expect(consoleSpy.calledWith("5")).to.be.true;
@@ -1609,13 +1609,13 @@ describe("serverless-wsgi", () => {
       sandbox.stub(fse, "readFileSync").returns("print(1+4)");
       plugin.hooks["wsgi:exec:exec"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"exec","data":"print(1+4)"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"exec","data":"print(1+4)"}}'
         );
         expect(consoleSpy.calledWith({ response: "5" })).to.be.true;
@@ -1702,13 +1702,13 @@ describe("serverless-wsgi", () => {
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"exec","data":"print(1+4)"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"exec","data":"print(1+4)"}}'
         );
         expect(consoleSpy.calledWith("5")).to.be.true;
@@ -1745,13 +1745,13 @@ describe("serverless-wsgi", () => {
       sandbox.stub(fse, "readFileSync").returns("print(1+4)");
       plugin.hooks["wsgi:exec:local:exec"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"exec","data":"print(1+4)"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"exec","data":"print(1+4)"}}'
         );
         expect(consoleSpy.calledWith({ response: "5" })).to.be.true;
@@ -1831,13 +1831,13 @@ describe("serverless-wsgi", () => {
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"command","data":"pwd"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"command","data":"pwd"}}'
         );
         expect(consoleSpy.calledWith("non-json output")).to.be.true;
@@ -1874,13 +1874,13 @@ describe("serverless-wsgi", () => {
       sandbox.stub(fse, "readFileSync").returns("pwd");
       plugin.hooks["wsgi:command:command"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"command","data":"pwd"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"command","data":"pwd"}}'
         );
         expect(consoleSpy.calledWith("/var/task")).to.be.true;
@@ -1960,13 +1960,13 @@ describe("serverless-wsgi", () => {
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"command","data":"pwd"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"command","data":"pwd"}}'
         );
         expect(consoleSpy.calledWith("non-json output")).to.be.true;
@@ -2003,13 +2003,13 @@ describe("serverless-wsgi", () => {
       sandbox.stub(fse, "readFileSync").returns("pwd");
       plugin.hooks["wsgi:command:local:command"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"command","data":"pwd"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"command","data":"pwd"}}'
         );
         expect(consoleSpy.calledWith("/var/task")).to.be.true;
@@ -2047,13 +2047,13 @@ describe("serverless-wsgi", () => {
       let consoleSpy = sandbox.spy(console, "log");
       plugin.hooks["wsgi:manage:manage"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"manage","data":"check"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"manage","data":"check"}}'
         );
         expect(consoleSpy.calledWith("manage command output")).to.be.true;
@@ -2094,13 +2094,13 @@ describe("serverless-wsgi", () => {
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"manage","data":"check"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"manage","data":"check"}}'
         );
         expect(consoleSpy.calledWith("manage command output")).to.be.true;
@@ -2138,13 +2138,13 @@ describe("serverless-wsgi", () => {
       let consoleSpy = sandbox.spy(console, "log");
       plugin.hooks["wsgi:flask:flask"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"flask","data":"check"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"flask","data":"check"}}'
         );
         expect(consoleSpy.calledWith("flask command output")).to.be.true;
@@ -2185,13 +2185,13 @@ describe("serverless-wsgi", () => {
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
-        expect(plugin.serverless.pluginManager.cliOptions.function).to.equal(
+        expect(plugin.options.function).to.equal(
           "app"
         );
         expect(plugin.serverless.pluginManager.cliOptions.d).to.equal(
           '{"_serverless-wsgi":{"command":"flask","data":"check"}}'
         );
-        expect(plugin.serverless.pluginManager.cliOptions.data).to.equal(
+        expect(plugin.options.data).to.equal(
           '{"_serverless-wsgi":{"command":"flask","data":"check"}}'
         );
         expect(consoleSpy.calledWith("flask command output")).to.be.true;


### PR DESCRIPTION
In serverless 2.32, they appear to have changed the way that it gets the options from the plugins. 

These changes fixed my issues and I can once again run `serverless wsgi manage` against serverless version 2.55.0