### PR TITLE
Upgrade to rely on `package.patterns`

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,13 +86,11 @@ class ServerlessWSGI {
   configurePackaging() {
     return new BbPromise((resolve) => {
       this.serverless.service.package = this.serverless.service.package || {};
-      this.serverless.service.package.include =
-        this.serverless.service.package.include || [];
-      this.serverless.service.package.exclude =
-        this.serverless.service.package.exclude || [];
+      this.serverless.service.package.patterns =
+        this.serverless.service.package.patterns || [];
 
-      this.serverless.service.package.include = _.union(
-        this.serverless.service.package.include,
+      this.serverless.service.package.patterns = _.union(
+        this.serverless.service.package.patterns,
         _.map(
           ["wsgi_handler.py", "serverless_wsgi.py", ".serverless-wsgi"],
           (artifact) =>
@@ -107,11 +105,11 @@ class ServerlessWSGI {
       );
 
       if (this.enableRequirements) {
-        this.serverless.service.package.exclude.push(
-          path.join(
+        this.serverless.service.package.patterns.push(
+          `!${path.join(
             path.relative(this.serverless.config.servicePath, this.appPath),
             ".requirements/**"
-          )
+          )}`
         );
       }
 
@@ -262,8 +260,8 @@ class ServerlessWSGI {
             file
           );
 
-          this.serverless.service.package.include.push(relativePath);
-          this.serverless.service.package.include.push(`${relativePath}/**`);
+          this.serverless.service.package.patterns.push(relativePath);
+          this.serverless.service.package.patterns.push(`${relativePath}/**`);
 
           try {
             fse.symlinkSync(`${this.requirementsInstallPath}/${file}`, file);

--- a/index.test.js
+++ b/index.test.js
@@ -75,7 +75,7 @@ describe("serverless-wsgi", () => {
       var copyStub = sandbox.stub(fse, "copyAsync");
       var writeStub = sandbox.stub(fse, "writeFileAsync");
       var procStub = sandbox.stub(child_process, "spawnSync");
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(copyStub.called).to.be.false;
         expect(writeStub.called).to.be.false;
@@ -105,7 +105,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           copyStub.calledWith(
@@ -166,7 +166,7 @@ describe("serverless-wsgi", () => {
       sandbox.stub(fse, "copyAsync");
       var writeStub = sandbox.stub(fse, "writeFileAsync");
       sandbox.stub(child_process, "spawnSync").returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(writeStub.calledWith("/tmp/.serverless-wsgi")).to.be.true;
         expect(JSON.parse(writeStub.lastCall.args[1])).to.deep.equal({
@@ -202,7 +202,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python3.6")).to.be.true;
         expect(
           procStub.calledWith("python", [
@@ -231,7 +231,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       var removeStub = sandbox.stub(fse, "removeAsync");
-      plugin.hooks["after:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["after:package:createDeploymentArtifacts"]().then(() => {
         expect(removeStub.calledWith("/tmp/wsgi_handler.py")).to.be.true;
         expect(removeStub.calledWith("/tmp/serverless_wsgi.py")).to.be.true;
         expect(removeStub.calledWith("/tmp/.serverless-wsgi")).to.be.true;
@@ -268,7 +268,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           copyStub.calledWith(
@@ -339,7 +339,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           copyStub.calledWith(
@@ -409,7 +409,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(copyStub.called).to.be.true;
         expect(writeStub.called).to.be.true;
@@ -464,7 +464,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.called).to.be.false;
         expect(copyStub.called).to.be.true;
         expect(writeStub.called).to.be.true;
@@ -515,7 +515,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(copyStub.called).to.be.true;
         expect(writeStub.called).to.be.true;
         expect(
@@ -616,7 +616,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(copyStub.called).to.be.false;
         expect(writeStub.called).to.be.false;
@@ -656,7 +656,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python3.6")).to.be.true;
         expect(copyStub.called).to.be.false;
         expect(writeStub.called).to.be.false;
@@ -692,7 +692,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(copyStub.called).to.be.false;
         expect(writeStub.called).to.be.false;
@@ -799,7 +799,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(copyStub.called).to.be.true;
         expect(writeStub.called).to.be.true;
@@ -828,7 +828,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       var removeStub = sandbox.stub(fse, "removeAsync");
-      plugin.hooks["after:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["after:package:createDeploymentArtifacts"]().then(() => {
         expect(removeStub.calledWith("/tmp/wsgi_handler.py")).to.be.true;
         expect(removeStub.calledWith("/tmp/serverless_wsgi.py")).to.be.true;
         expect(removeStub.calledWith("/tmp/.serverless-wsgi")).to.be.true;
@@ -860,7 +860,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
+      return plugin.hooks["before:package:createDeploymentArtifacts"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(copyStub.called).to.be.true;
         expect(writeStub.called).to.be.true;
@@ -900,7 +900,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:deploy:function:packageFunction"]().then(() => {
+      return plugin.hooks["before:deploy:function:packageFunction"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(copyStub.called).to.be.false;
         expect(writeStub.called).to.be.false;
@@ -936,7 +936,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["before:deploy:function:packageFunction"]().then(() => {
+      return plugin.hooks["before:deploy:function:packageFunction"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           copyStub.calledWith(
@@ -990,7 +990,7 @@ describe("serverless-wsgi", () => {
       existsStub.withArgs("werkzeug").returns(false);
       sandbox.stub(fse, "readdirSync").returns(["flask", "werkzeug"]);
       var unlinkStub = sandbox.stub(fse, "unlinkSync");
-      plugin.hooks["after:deploy:function:packageFunction"]().then(() => {
+      return plugin.hooks["after:deploy:function:packageFunction"]().then(() => {
         expect(existsStub.calledWith("/tmp/.requirements")).to.be.true;
         expect(unlinkStub.calledWith("flask")).to.be.true;
         expect(unlinkStub.calledWith("werkzeug")).to.be.false;
@@ -1032,7 +1032,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       var hasbinStub = sandbox.stub(hasbin, "sync").returns(true);
       var procStub = sandbox.stub(child_process, "spawnSync").returns({});
-      plugin.hooks["wsgi:serve:serve"]().then(() => {
+      return plugin.hooks["wsgi:serve:serve"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           procStub.calledWith(
@@ -1070,7 +1070,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ error: "Something failed" });
-      expect(
+      return expect(
         plugin.hooks["wsgi:serve:serve"]()
       ).to.eventually.be.rejected.and.notify(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
@@ -1110,7 +1110,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ error: { code: "ENOENT" } });
-      expect(
+      return expect(
         plugin.hooks["wsgi:serve:serve"]()
       ).to.eventually.be.rejected.and.notify(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
@@ -1148,7 +1148,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       var hasbinStub = sandbox.stub(hasbin, "sync").returns(true);
       var procStub = sandbox.stub(child_process, "spawnSync").returns({});
-      plugin.hooks["wsgi:serve:serve"]().then(() => {
+      return plugin.hooks["wsgi:serve:serve"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           procStub.calledWith(
@@ -1184,7 +1184,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       var hasbinStub = sandbox.stub(hasbin, "sync").returns(true);
       var procStub = sandbox.stub(child_process, "spawnSync").returns({});
-      plugin.hooks["wsgi:serve:serve"]().then(() => {
+      return plugin.hooks["wsgi:serve:serve"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           procStub.calledWith(
@@ -1220,7 +1220,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       var hasbinStub = sandbox.stub(hasbin, "sync").returns(true);
       var procStub = sandbox.stub(child_process, "spawnSync").returns({});
-      plugin.hooks["wsgi:serve:serve"]().then(() => {
+      return plugin.hooks["wsgi:serve:serve"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           procStub.calledWith(
@@ -1257,7 +1257,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       var hasbinStub = sandbox.stub(hasbin, "sync").returns(true);
       var procStub = sandbox.stub(child_process, "spawnSync").returns({});
-      plugin.hooks["wsgi:serve:serve"]().then(() => {
+      return plugin.hooks["wsgi:serve:serve"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           procStub.calledWith(
@@ -1295,7 +1295,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       var hasbinStub = sandbox.stub(hasbin, "sync").returns(true);
       var procStub = sandbox.stub(child_process, "spawnSync").returns({});
-      plugin.hooks["wsgi:serve:serve"]().then(() => {
+      return plugin.hooks["wsgi:serve:serve"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           procStub.calledWith(
@@ -1347,7 +1347,7 @@ describe("serverless-wsgi", () => {
       sandbox.stub(hasbin, "sync").returns(true);
       sandbox.stub(child_process, "spawnSync").returns({});
       sandbox.stub(process, "env").value({});
-      plugin.hooks["wsgi:serve:serve"]().then(() => {
+      return plugin.hooks["wsgi:serve:serve"]().then(() => {
         expect(process.env.SOME_ENV_VAR).to.equal(42);
         expect(process.env.SECOND_VAR).to.equal(33);
         expect(process.env.THIRD_VAR).to.be.undefined;
@@ -1377,7 +1377,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       var hasbinStub = sandbox.stub(hasbin, "sync").returns(true);
       var procStub = sandbox.stub(child_process, "spawnSync").returns({});
-      plugin.hooks["wsgi:serve:serve"]().then(() => {
+      return plugin.hooks["wsgi:serve:serve"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           procStub.calledWith(
@@ -1421,7 +1421,7 @@ describe("serverless-wsgi", () => {
       var procStub = sandbox
         .stub(child_process, "spawnSync")
         .returns({ status: 0 });
-      plugin.hooks["wsgi:install:install"]().then(() => {
+      return plugin.hooks["wsgi:install:install"]().then(() => {
         expect(hasbinStub.calledWith("python2.7")).to.be.true;
         expect(
           copyStub.calledWith(
@@ -1472,7 +1472,7 @@ describe("serverless-wsgi", () => {
       var existsStub = sandbox.stub(fse, "existsSync").returns(true);
       sandbox.stub(fse, "readdirSync").returns(["flask"]);
       var unlinkStub = sandbox.stub(fse, "unlinkSync");
-      plugin.hooks["wsgi:clean:clean"]().then(() => {
+      return plugin.hooks["wsgi:clean:clean"]().then(() => {
         expect(existsStub.calledWith("/tmp/.requirements")).to.be.true;
         expect(unlinkStub.calledWith("flask")).to.be.true;
         expect(removeStub.calledWith("/tmp/wsgi_handler.py")).to.be.true;
@@ -1504,7 +1504,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       var removeStub = sandbox.stub(fse, "removeAsync");
       var existsStub = sandbox.stub(fse, "existsSync").returns(true);
-      plugin.hooks["wsgi:clean:clean"]().then(() => {
+      return plugin.hooks["wsgi:clean:clean"]().then(() => {
         expect(existsStub.calledWith("/tmp/.requirements")).to.be.false;
         expect(removeStub.calledWith("/tmp/wsgi_handler.py")).to.be.true;
         expect(removeStub.calledWith("/tmp/serverless_wsgi.py")).to.be.true;
@@ -1561,7 +1561,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
-      plugin.hooks["wsgi:exec:exec"]().then(() => {
+      return plugin.hooks["wsgi:exec:exec"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.c).to.be.undefined;
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
@@ -1607,7 +1607,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
       sandbox.stub(fse, "readFileSync").returns("print(1+4)");
-      plugin.hooks["wsgi:exec:exec"]().then(() => {
+      return plugin.hooks["wsgi:exec:exec"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
         expect(plugin.options.function).to.equal(
           "app"
@@ -1647,7 +1647,7 @@ describe("serverless-wsgi", () => {
         { command: "print(1+4)" }
       );
 
-      expect(plugin.hooks["wsgi:exec:exec"]()).to.be.rejectedWith("Error");
+      return expect(plugin.hooks["wsgi:exec:exec"]()).to.be.rejectedWith("Error");
     });
   });
 
@@ -1666,7 +1666,7 @@ describe("serverless-wsgi", () => {
         {}
       );
 
-      expect(plugin.hooks["wsgi:exec:local:exec"]()).to.be.rejectedWith(
+      return expect(plugin.hooks["wsgi:exec:local:exec"]()).to.be.rejectedWith(
         "Please provide either a command (-c) or a file (-f)"
       );
     });
@@ -1697,7 +1697,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
-      plugin.hooks["wsgi:exec:local:exec"]().then(() => {
+      return plugin.hooks["wsgi:exec:local:exec"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.c).to.be.undefined;
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
@@ -1743,7 +1743,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
       sandbox.stub(fse, "readFileSync").returns("print(1+4)");
-      plugin.hooks["wsgi:exec:local:exec"]().then(() => {
+      return plugin.hooks["wsgi:exec:local:exec"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
         expect(plugin.options.function).to.equal(
           "app"
@@ -1776,7 +1776,7 @@ describe("serverless-wsgi", () => {
         { command: "pwd" }
       );
 
-      expect(plugin.hooks["wsgi:command:command"]()).to.be.rejectedWith(
+      return expect(plugin.hooks["wsgi:command:command"]()).to.be.rejectedWith(
         "No functions were found with handler: wsgi_handler.handler"
       );
     });
@@ -1795,7 +1795,7 @@ describe("serverless-wsgi", () => {
         {}
       );
 
-      expect(plugin.hooks["wsgi:command:command"]()).to.be.rejectedWith(
+      return expect(plugin.hooks["wsgi:command:command"]()).to.be.rejectedWith(
         "Please provide either a command (-c) or a file (-f)"
       );
     });
@@ -1826,7 +1826,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
-      plugin.hooks["wsgi:command:command"]().then(() => {
+      return plugin.hooks["wsgi:command:command"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.c).to.be.undefined;
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
@@ -1872,7 +1872,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
       sandbox.stub(fse, "readFileSync").returns("pwd");
-      plugin.hooks["wsgi:command:command"]().then(() => {
+      return plugin.hooks["wsgi:command:command"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
         expect(plugin.options.function).to.equal(
           "app"
@@ -1905,7 +1905,7 @@ describe("serverless-wsgi", () => {
         { command: "pwd" }
       );
 
-      expect(plugin.hooks["wsgi:command:local:command"]()).to.be.rejectedWith(
+      return expect(plugin.hooks["wsgi:command:local:command"]()).to.be.rejectedWith(
         "No functions were found with handler: wsgi_handler.handler"
       );
     });
@@ -1924,7 +1924,7 @@ describe("serverless-wsgi", () => {
         {}
       );
 
-      expect(plugin.hooks["wsgi:command:local:command"]()).to.be.rejectedWith(
+      return expect(plugin.hooks["wsgi:command:local:command"]()).to.be.rejectedWith(
         "Please provide either a command (-c) or a file (-f)"
       );
     });
@@ -1955,7 +1955,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
-      plugin.hooks["wsgi:command:local:command"]().then(() => {
+      return plugin.hooks["wsgi:command:local:command"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.c).to.be.undefined;
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
@@ -2001,7 +2001,7 @@ describe("serverless-wsgi", () => {
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
       sandbox.stub(fse, "readFileSync").returns("pwd");
-      plugin.hooks["wsgi:command:local:command"]().then(() => {
+      return plugin.hooks["wsgi:command:local:command"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
         expect(plugin.options.function).to.equal(
           "app"
@@ -2045,7 +2045,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
-      plugin.hooks["wsgi:manage:manage"]().then(() => {
+      return plugin.hooks["wsgi:manage:manage"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
         expect(plugin.options.function).to.equal(
           "app"
@@ -2089,7 +2089,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
-      plugin.hooks["wsgi:manage:local:manage"]().then(() => {
+      return plugin.hooks["wsgi:manage:local:manage"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.c).to.be.undefined;
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
@@ -2136,7 +2136,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
-      plugin.hooks["wsgi:flask:flask"]().then(() => {
+      return plugin.hooks["wsgi:flask:flask"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.f).to.equal("app");
         expect(plugin.options.function).to.equal(
           "app"
@@ -2180,7 +2180,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       let consoleSpy = sandbox.spy(console, "log");
-      plugin.hooks["wsgi:flask:local:flask"]().then(() => {
+      return plugin.hooks["wsgi:flask:local:flask"]().then(() => {
         expect(plugin.serverless.pluginManager.cliOptions.c).to.be.undefined;
         expect(plugin.serverless.pluginManager.cliOptions.context).to.be
           .undefined;
@@ -2222,31 +2222,32 @@ describe("serverless-wsgi", () => {
       );
 
       // Test invocation for non-WSGI function, should do nothing
-      expect(plugin.hooks["before:invoke:local:invoke"]()).to.be.fulfilled;
+      return expect(plugin.hooks["before:invoke:local:invoke"]()).to.be.fulfilled.then(() => {
 
-      plugin.options.function = "app";
+        plugin.options.function = "app";
 
-      var sandbox = sinon.createSandbox();
-      var copyStub = sandbox.stub(fse, "copyAsync");
-      var writeStub = sandbox.stub(fse, "writeFileAsync");
-      plugin.hooks["before:invoke:local:invoke"]().then(() => {
-        expect(
-          copyStub.calledWith(
-            path.resolve(__dirname, "wsgi_handler.py"),
-            "/tmp/wsgi_handler.py"
-          )
-        ).to.be.true;
-        expect(
-          copyStub.calledWith(
-            path.resolve(__dirname, "serverless_wsgi.py"),
-            "/tmp/serverless_wsgi.py"
-          )
-        ).to.be.true;
-        expect(writeStub.calledWith("/tmp/.serverless-wsgi")).to.be.true;
-        expect(JSON.parse(writeStub.lastCall.args[1])).to.deep.equal({
-          app: "api.app"
+        var sandbox = sinon.createSandbox();
+        var copyStub = sandbox.stub(fse, "copyAsync");
+        var writeStub = sandbox.stub(fse, "writeFileAsync");
+        return plugin.hooks["before:invoke:local:invoke"]().then(() => {
+          expect(
+            copyStub.calledWith(
+              path.resolve(__dirname, "wsgi_handler.py"),
+              "/tmp/wsgi_handler.py"
+            )
+          ).to.be.true;
+          expect(
+            copyStub.calledWith(
+              path.resolve(__dirname, "serverless_wsgi.py"),
+              "/tmp/serverless_wsgi.py"
+            )
+          ).to.be.true;
+          expect(writeStub.calledWith("/tmp/.serverless-wsgi")).to.be.true;
+          expect(JSON.parse(writeStub.lastCall.args[1])).to.deep.equal({
+            app: "api.app"
+          });
+          sandbox.restore();
         });
-        sandbox.restore();
       });
     });
 
@@ -2269,7 +2270,7 @@ describe("serverless-wsgi", () => {
 
       var sandbox = sinon.createSandbox();
       var removeStub = sandbox.stub(fse, "removeAsync");
-      plugin.hooks["after:invoke:local:invoke"]().then(() => {
+      return plugin.hooks["after:invoke:local:invoke"]().then(() => {
         expect(removeStub.calledWith("/tmp/wsgi_handler.py")).to.be.true;
         expect(removeStub.calledWith("/tmp/serverless_wsgi.py")).to.be.true;
         expect(removeStub.calledWith("/tmp/.serverless-wsgi")).to.be.true;

--- a/index.test.js
+++ b/index.test.js
@@ -131,13 +131,11 @@ describe("serverless-wsgi", () => {
           ])
         ).to.be.true;
         sandbox.restore();
-        expect(plugin.serverless.service.package.include).to.have.members([
+        expect(plugin.serverless.service.package.patterns).to.have.members([
           "wsgi_handler.py",
           "serverless_wsgi.py",
-          ".serverless-wsgi"
-        ]);
-        expect(plugin.serverless.service.package.exclude).to.have.members([
-          ".requirements/**"
+          ".serverless-wsgi",
+          "!.requirements/**"
         ]);
       });
     });
@@ -296,17 +294,15 @@ describe("serverless-wsgi", () => {
           ])
         ).to.be.true;
         sandbox.restore();
-        expect(plugin.serverless.service.package.include).to.have.members([
+        expect(plugin.serverless.service.package.patterns).to.have.members([
           "wsgi_handler.py",
           "serverless_wsgi.py",
           ".serverless-wsgi",
           "web/flask",
           "web/flask/**",
           "web/werkzeug",
-          "web/werkzeug/**"
-        ]);
-        expect(plugin.serverless.service.package.exclude).to.have.members([
-          "web/.requirements/**"
+          "web/werkzeug/**",
+          "!web/.requirements/**"
         ]);
       });
     });
@@ -367,17 +363,15 @@ describe("serverless-wsgi", () => {
           ])
         ).to.be.true;
         sandbox.restore();
-        expect(plugin.serverless.service.package.include).to.have.members([
+        expect(plugin.serverless.service.package.patterns).to.have.members([
           "web/wsgi_handler.py",
           "web/serverless_wsgi.py",
           "web/.serverless-wsgi",
           "web/flask",
           "web/flask/**",
           "web/werkzeug",
-          "web/werkzeug/**"
-        ]);
-        expect(plugin.serverless.service.package.exclude).to.have.members([
-          "web/.requirements/**"
+          "web/werkzeug/**",
+          "!web/.requirements/**"
         ]);
       });
     });
@@ -391,7 +385,7 @@ describe("serverless-wsgi", () => {
           service: {
             provider: { runtime: "python2.7" },
             custom: { wsgi: { app: "api.app" } },
-            package: { include: ["sample.txt"] }
+            package: { patterns: ["sample.txt"] }
           },
           classes: { Error: Error },
           cli: { log: () => {} }
@@ -422,18 +416,16 @@ describe("serverless-wsgi", () => {
             "/tmp/.requirements"
           ])
         ).to.be.true;
-        expect(plugin.serverless.service.package.include).to.have.members([
+        expect(plugin.serverless.service.package.patterns).to.have.members([
           "sample.txt",
           "wsgi_handler.py",
           "serverless_wsgi.py",
           ".serverless-wsgi",
+          "!.requirements/**",
           "flask",
           "flask/**",
           "werkzeug",
           "werkzeug/**"
-        ]);
-        expect(plugin.serverless.service.package.exclude).to.have.members([
-          ".requirements/**"
         ]);
         sandbox.restore();
       });
@@ -446,7 +438,7 @@ describe("serverless-wsgi", () => {
           service: {
             provider: { runtime: "python2.7" },
             custom: { wsgi: { app: "api.app", pythonBin: "my-python" } },
-            package: { include: ["sample.txt"] }
+            package: { patterns: ["sample.txt"] }
           },
           classes: { Error: Error },
           cli: { log: () => {} }
@@ -477,16 +469,14 @@ describe("serverless-wsgi", () => {
             "/tmp/.requirements"
           ])
         ).to.be.true;
-        expect(plugin.serverless.service.package.include).to.have.members([
+        expect(plugin.serverless.service.package.patterns).to.have.members([
           "sample.txt",
           "wsgi_handler.py",
           "serverless_wsgi.py",
           ".serverless-wsgi",
           "flask",
-          "flask/**"
-        ]);
-        expect(plugin.serverless.service.package.exclude).to.have.members([
-          ".requirements/**"
+          "flask/**",
+          "!.requirements/**"
         ]);
         sandbox.restore();
       });
@@ -526,15 +516,13 @@ describe("serverless-wsgi", () => {
             "/tmp/api/.requirements"
           ])
         ).to.be.true;
-        expect(plugin.serverless.service.package.include).to.have.members([
+        expect(plugin.serverless.service.package.patterns).to.have.members([
           "wsgi_handler.py",
           "serverless_wsgi.py",
           ".serverless-wsgi",
           "api/werkzeug",
-          "api/werkzeug/**"
-        ]);
-        expect(plugin.serverless.service.package.exclude).to.have.members([
-          "api/.requirements/**"
+          "api/werkzeug/**",
+          "!api/.requirements/**"
         ]);
         sandbox.restore();
       });
@@ -697,8 +685,11 @@ describe("serverless-wsgi", () => {
         expect(copyStub.called).to.be.false;
         expect(writeStub.called).to.be.false;
         expect(procStub.called).to.be.false;
-        expect(plugin.serverless.service.package.exclude).to.have.members([
-          ".requirements/**"
+        expect(plugin.serverless.service.package.patterns).to.have.members([
+          "wsgi_handler.py",
+          "serverless_wsgi.py",
+          ".serverless-wsgi",
+          "!.requirements/**"
         ]);
         sandbox.restore();
       });
@@ -805,7 +796,7 @@ describe("serverless-wsgi", () => {
         expect(writeStub.called).to.be.true;
         expect(existsStub.called).to.be.false;
         expect(procStub.called).to.be.false;
-        expect(plugin.serverless.service.package.include).not.to.have.members([
+        expect(plugin.serverless.service.package.patterns).not.to.have.members([
           ".requirements/**"
         ]);
         sandbox.restore();
@@ -866,7 +857,7 @@ describe("serverless-wsgi", () => {
         expect(writeStub.called).to.be.true;
         expect(existsStub.called).to.be.false;
         expect(procStub.called).to.be.false;
-        expect(plugin.serverless.service.package.include).not.to.have.members([
+        expect(plugin.serverless.service.package.patterns).not.to.have.members([
           ".requirements/**"
         ]);
         sandbox.restore();

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "fs-extra": "^9.1.0",
     "hasbin": "^1.2.3",
     "lodash": "^4.17.21"
+  },
+  "peerDependences": {
+    "serverless": "^2.32.0"
   }
 }


### PR DESCRIPTION
Support for `package.include` is [deprecated on Serverless Framework side](https://serverless.com/framework/docs/deprecations#new-way-to-define-packaging-patterns) and is scheduled to be removed with v3

This PR ensures that plugin internally relies on `package.patterns` as first choice.

I've additionally added `serverless` as peer dependency and indicated minimal version which supports `package.patterns`

I believe this should be considered as breaking change (as will stop working with Framework versions below 2.32.0) and should be released as a new major

Additionally I've fixed promises handling in tests (they weren't returned which in some cases resulted in improper communication of failures)