### PR TITLE
Custom ssl certs option for serve command

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,6 +382,8 @@ class ServerlessWSGI {
       const disable_threading = this.options["disable-threading"] || false;
       const num_processes = this.options["num-processes"] || 1;
       const ssl = this.options.ssl || false;
+      const ssl_pub = this.options["ssl-pub"] || "";
+      const ssl_pri = this.options["ssl-pri"] || "";
 
       var args = [
         path.resolve(__dirname, "serve.py"),
@@ -401,6 +403,14 @@ class ServerlessWSGI {
 
       if (ssl) {
         args.push("--ssl");
+      }
+
+      if (ssl_pub) {
+        args.push("--ssl-pub", ssl_pub);
+      }
+
+      if (ssl_pri) {
+        args.push("--ssl-pri", ssl_pri);
       }
 
       var status = child_process.spawnSync(this.pythonBin, args, {
@@ -584,6 +594,14 @@ class ServerlessWSGI {
                 type: "boolean",
                 usage: "Enable local serving using HTTPS",
               },
+              "ssl-pub": {
+                type: "string",
+                usage: "local ssl pem file to use for ssl"
+              },
+              "ssl-pri": {
+                type: "string",
+                usage: "local ssl pem file to use for ssl private key"
+              }
             },
           },
           install: {


### PR DESCRIPTION
This PR is meant to resolves logandk/serverless-wsgi#166

I left the current flag `--ssl` as it is, so it will still create ssl certs 'adhoc'.

I added two new flags to the `sls wsgi serve` command. They are `--ssl-pri` and `--ssl-pub`. 
These flags take file paths to custom ssl certs that are to be used to serve the app locally over https. The syntax is `--ssl-pri ~/localhost-key.pem --ssl-pub ~/localhost.pem`. This will serve the app over https using these ssl certs. The ssl certs can be generated via a tool like [mkcert](https://github.com/FiloSottile/mkcert)

Also, updated the tests to keep the same code coverage as before.