### PR TITLE
Fixes for Scaleway

### DIFF
--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -180,6 +180,7 @@ def handle_request(app, event, context):
     if (
         event.get("version") is None
         and event.get("isBase64Encoded") is None
+        and event.get("requestPath") is not None
         and not is_alb_event(event)
     ):
         return handle_lambda_integration(app, event, context)

--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -136,7 +136,7 @@ def setup_environ_items(environ, headers):
 def generate_response(response, event):
     returndict = {"statusCode": response.status_code}
 
-    if "multiValueHeaders" in event:
+    if "multiValueHeaders" in event and event["multiValueHeaders"]:
         returndict["multiValueHeaders"] = group_headers(response.headers)
     else:
         returndict["headers"] = split_headers(response.headers)
@@ -192,7 +192,7 @@ def handle_request(app, event, context):
 
 
 def handle_payload_v1(app, event, context):
-    if "multiValueHeaders" in event:
+    if "multiValueHeaders" in event and event["multiValueHeaders"]:
         headers = Headers(event["multiValueHeaders"])
     else:
         headers = Headers(event["headers"])

--- a/serverless_wsgi.py
+++ b/serverless_wsgi.py
@@ -220,8 +220,8 @@ def handle_payload_v1(app, event, context):
         "REMOTE_ADDR": event.get("requestContext", {})
         .get("identity", {})
         .get("sourceIp", ""),
-        "REMOTE_USER": event.get("requestContext", {})
-        .get("authorizer", {})
+        "REMOTE_USER": (event.get("requestContext", {})
+                        .get("authorizer") or {})
         .get("principalId", ""),
         "REQUEST_METHOD": event.get("httpMethod", {}),
         "SCRIPT_NAME": script_name,


### PR DESCRIPTION
On Scaleway at least, authorizer is often None:

    "requestContext": {
      "accountId": "",
      "resourceId": "",
      "stage": "",
      "requestId": "",
      "resourcePath": "",
      "authorizer": None,
      "httpMethod": "GET",
      "apiId": ""
    },

Also, `isBase64Encoded` is sometimes missing, while the rest of the event is obviously v1.
`multiValueHeaders` is often `None` instead of missing or `{}`.