### PR TITLE
Resolve / #244 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   env: {
     es6: true,
     node: true,
+    mocha: true,
   },
   extends: "eslint:recommended",
   parserOptions: {

--- a/index.js
+++ b/index.js
@@ -498,7 +498,7 @@ class ServerlessWSGI {
     // remotely, we get a string back and we want it to appear in the console as it would have
     // if it was invoked locally.
     //
-    // We capture stdout output in order to parse the array returned from the lambda invocation,
+    // We capture stdout output in order to parse the array returned from the lambda invocation, 
     // then restore stdout.
     let output = "";
 

--- a/index.js
+++ b/index.js
@@ -434,13 +434,29 @@ class ServerlessWSGI {
   }
 
   findHandler() {
-    return _.findKey(this.serverless.service.functions, (fun) =>
-      _.includes(fun.handler, "wsgi_handler.handler")
-    );
+    const functionName = this.options.function || this.options.f;
+
+    if (functionName) {
+      // If the function name is specified, return it directly
+      if (this.serverless.service.functions[functionName]) {
+        return functionName;
+      } else {
+        throw new Error(`Function "${functionName}" not found.`);
+      }
+    } else {
+      return _.findKey(this.serverless.service.functions, (fun) =>
+        _.includes(fun.handler, "wsgi_handler.handler")
+      );
+    }
   }
 
   invokeHandler(command, data, local) {
-    const handlerFunction = this.findHandler();
+    let handlerFunction;
+    try {
+      handlerFunction = this.findHandler();
+    } catch (error) {
+      return BbPromise.reject(error.message);
+    }
 
     if (!handlerFunction) {
       return BbPromise.reject(
@@ -482,7 +498,7 @@ class ServerlessWSGI {
     // remotely, we get a string back and we want it to appear in the console as it would have
     // if it was invoked locally.
     //
-    // We capture stdout output in order to parse the array returned from the lambda invocation, 
+    // We capture stdout output in order to parse the array returned from the lambda invocation,
     // then restore stdout.
     let output = "";
 

--- a/index.js
+++ b/index.js
@@ -434,29 +434,13 @@ class ServerlessWSGI {
   }
 
   findHandler() {
-    const functionName = this.options.function || this.options.f;
-
-    if (functionName) {
-      // If the function name is specified, return it directly
-      if (this.serverless.service.functions[functionName]) {
-        return functionName;
-      } else {
-        throw new Error(`Function "${functionName}" not found.`);
-      }
-    } else {
-      return _.findKey(this.serverless.service.functions, (fun) =>
-        _.includes(fun.handler, "wsgi_handler.handler")
-      );
-    }
+    return _.findKey(this.serverless.service.functions, (fun) =>
+      _.includes(fun.handler, "wsgi_handler.handler")
+    );
   }
 
   invokeHandler(command, data, local) {
-    let handlerFunction;
-    try {
-      handlerFunction = this.findHandler();
-    } catch (error) {
-      return BbPromise.reject(error.message);
-    }
+    const handlerFunction = this.findHandler();
 
     if (!handlerFunction) {
       return BbPromise.reject(
@@ -498,7 +482,7 @@ class ServerlessWSGI {
     // remotely, we get a string back and we want it to appear in the console as it would have
     // if it was invoked locally.
     //
-    // We capture stdout output in order to parse the array returned from the lambda invocation,
+    // We capture stdout output in order to parse the array returned from the lambda invocation, 
     // then restore stdout.
     let output = "";
 
@@ -517,6 +501,7 @@ class ServerlessWSGI {
       }
     );
     /* eslint-enable no-unused-vars */
+
 
     return this.serverless.pluginManager
       .run(local ? ["invoke", "local"] : ["invoke"])


### PR DESCRIPTION
# Resolve #244 

### What Added/Updated
It now supports the --function and -f switches. If either switch is used in the command ```sls wsgi manage --function <function_name> or -f <function_name>```, it will take that function name. If the specified function is not found, it will throw an error, which is handled in invokeHandler. If neither switch is present, it will return the first function with the condition handler: wsgi_handler.handler, as it did before. Let me know if you need any more changes/help!