### PR TITLE
fixed app imort failures not being logged

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,14 +12,14 @@ jobs:
           - { name: "3.8", python: "3.8", os: ubuntu-latest }
           - { name: "3.7", python: "3.7", os: ubuntu-latest }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "14"
       - run: npm install
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: update pip
@@ -31,7 +31,7 @@ jobs:
         id: pip-cache
         run: echo "::set-output name=dir::$(pip cache dir)"
       - name: cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements.txt') }}
@@ -43,7 +43,7 @@ jobs:
       - run: npm run pytest
       - run: npm run pylint
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v4
         with:
           token: "89d22de7-bfaf-43a0-81da-33cc733fd294"
           fail_ci_if_error: true

--- a/wsgi_handler.py
+++ b/wsgi_handler.py
@@ -9,9 +9,11 @@ Author: Logan Raarup <logan@logan.dk>
 import importlib
 import io
 import json
+import logging
 import os
 import sys
 import traceback
+from werkzeug.exceptions import InternalServerError
 
 # Call decompression helper from `serverless-python-requirements` if
 # available. See: https://github.com/UnitedIncome/serverless-python-requirements#dealing-with-lambdas-size-limitations
@@ -44,8 +46,8 @@ def import_app(config):
 
         return getattr(wsgi_module, wsgi_fqn[1])
     except:  # noqa
-        traceback.print_exc()
-        raise Exception("Unable to import {}".format(config["app"]))
+        logging.exception("Unable to import app '{}' - {}".format(config["app"], str(e)), exc_info=e)
+        return InternalServerError("Unable to import app {}".format(config["app"]))
 
 
 def append_text_mime_types(config):

--- a/wsgi_handler.py
+++ b/wsgi_handler.py
@@ -45,9 +45,9 @@ def import_app(config):
         wsgi_module = importlib.import_module(wsgi_fqn_parts[-1])
 
         return getattr(wsgi_module, wsgi_fqn[1])
-    except:  # noqa
-        logging.exception("Unable to import app '{}' - {}".format(config["app"], str(e)), exc_info=e)
-        return InternalServerError("Unable to import app {}".format(config["app"]))
+    except Exception as err:
+        logging.exception("Unable to import app: '{}' - {}".format(config["app"], err))
+        return InternalServerError("Unable to import app: {}".format(config["app"]))
 
 
 def append_text_mime_types(config):

--- a/wsgi_handler_test.py
+++ b/wsgi_handler_test.py
@@ -813,18 +813,16 @@ def test_command_unknown(mock_wsgi_app_file, mock_app, wsgi_handler):
 
 
 def test_app_import_error(mock_wsgi_app_file, mock_app_with_import_error, event_v1, wsgi_handler):
-    with pytest.raises(ImportError, match="Unable to import app app.app"):
-        response = wsgi_handler.handler(event_v1, {})
-        pytest.exit(response)
-        assert response == {
-            "statusCode": 500,
-            "body": "<!doctype html>\n<html lang=en>\n<title>500 Internal Server Error</title>\n<h1>Internal Server Error</h1>\n<p>Unable to import app: app.app</p>\n",
-            "headers": {
-                "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": "140"
-            },
-            "isBase64Encoded": False
-        }
+    response = wsgi_handler.handler(event_v1, {})
+    assert response == {
+        "statusCode": 500,
+        "body": "<!doctype html>\n<html lang=en>\n<title>500 Internal Server Error</title>\n<h1>Internal Server Error</h1>\n<p>Unable to import app: app.app</p>\n",
+        "headers": {
+            "Content-Type": "text/html; charset=utf-8",
+            "Content-Length": "140"
+        },
+        "isBase64Encoded": False
+    }
 
 
 def test_handler_with_encoded_characters_in_path(

--- a/wsgi_handler_test.py
+++ b/wsgi_handler_test.py
@@ -812,11 +812,19 @@ def test_command_unknown(mock_wsgi_app_file, mock_app, wsgi_handler):
     assert "Exception: Unknown command: unknown" in response[1]
 
 
-def test_app_import_error(mock_wsgi_app_file, mock_app_with_import_error, event_v1):
-    with pytest.raises(Exception, match="Unable to import app.app"):
-        if "wsgi_handler" in sys.modules:
-            del sys.modules["wsgi_handler"]
-        import wsgi_handler  # noqa: F401
+def test_app_import_error(mock_wsgi_app_file, mock_app_with_import_error, event_v1, wsgi_handler):
+    with pytest.raises(ImportError, match="Unable to import app app.app"):
+        response = wsgi_handler.handler(event_v1, {})
+        pytest.exit(response)
+        assert response == {
+            "statusCode": 500,
+            "body": "<!doctype html>\n<html lang=en>\n<title>500 Internal Server Error</title>\n<h1>Internal Server Error</h1>\n<p>Unable to import app: app.app</p>\n",
+            "headers": {
+                "Content-Type": "text/html; charset=utf-8",
+                "Content-Length": "140"
+            },
+            "isBase64Encoded": False
+        }
 
 
 def test_handler_with_encoded_characters_in_path(


### PR DESCRIPTION
This PR fixes the issue where no log messages are added to CloudWatch during the  pre-start (app) setup.
This is a major issue when integration layers with the Lambda and import errors are thrown.

The messages will now be visible in the CloudWath log and an InternalServerError is returned to the client.

